### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.0 (06.12.2022)
+- Added [Continuation Command](https://github.com/kommitters/kadena.ex/issues/133)
+
 ## 0.8.0 (30.11.2022)
 
 - Added [PACT Command Behaviour](https://github.com/kommitters/kadena.ex/issues/132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 0.9.0 (06.12.2022)
+## 0.9.0 (08.12.2022)
 - Added [Continuation Command](https://github.com/kommitters/kadena.ex/issues/133)
+- Relocated Chainweb types
+- Improved the README documentation
 
 ## 0.8.0 (30.11.2022)
 

--- a/README.md
+++ b/README.md
@@ -23,21 +23,20 @@ Add `kadena` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:kadena, "~> 0.8.0"}
+    {:kadena, "~> 0.9.0"}
   ]
 end
 ```
 
 ## Roadmap
 
-The latest updated branch to target a PR is `v0.9`
+The latest updated branch to target a PR is `v0.10`
 
 You can see a big picture of the roadmap here: [**ROADMAP**][roadmap]
 
 ### What we're working on now 🎉
 
 - [Chainweb](https://github.com/kommitters/kadena.ex/issues/57)
-- [Pact Commands Builder](https://github.com/kommitters/kadena.ex/issues/131)
 
 ### Done - What we've already developed! 🚀
 
@@ -62,6 +61,7 @@ You can see a big picture of the roadmap here: [**ROADMAP**][roadmap]
 - [Wallet types](https://github.com/kommitters/kadena.ex/issues/18)
 - [Kadena Crypto](https://github.com/kommitters/kadena.ex/issues/51)
 - [Kadena Pact](https://github.com/kommitters/kadena.ex/issues/55)
+- [Pact Commands Builder](https://github.com/kommitters/kadena.ex/issues/131)
 
 </details>
 
@@ -75,7 +75,7 @@ These commands are intended to be used as the request body to the Pact API endpo
 There are two type of commands:
 
 - [`Execution`](#execution-command)
-- `Continuation`.
+- [`Continuation`](#continuation-command)
 
 ### Execution Command
 
@@ -87,20 +87,107 @@ To create an execution command is needed:
 - [EnvData](#envdata) (optional)
 - [MetaData](#metadata)
 - [KeyPairs](#keypair)
-- [Signers](#signerslist)
+- [Signers](#signerslist) / [Signer](#signer)
 
-The following example shows how to create an execution command:
+The following examples shows how to create an execution command:
 
 ```elixir
+# with a single KeyPair and Signer
 Kadena.Pact.ExecCommand.new()
   |> Kadena.Pact.ExecCommand.set_network(network_id)
   |> Kadena.Pact.ExecCommand.set_code(code)
   |> Kadena.Pact.ExecCommand.set_nonce(nonce)
   |> Kadena.Pact.ExecCommand.set_data(env_data)
-  |> Kadena.Pact.ExecCommand.set_metadata(keypair)
+  |> Kadena.Pact.ExecCommand.set_metadata(meta_data)
   |> Kadena.Pact.ExecCommand.add_keypair(keypair)
+  |> Kadena.Pact.ExecCommand.add_signer(signer)
+  |> Kadena.Pact.ExecCommand.build()
+
+# with a list of KeyPair and a SignersList
+Kadena.Pact.ExecCommand.new()
+  |> Kadena.Pact.ExecCommand.set_network(network_id)
+  |> Kadena.Pact.ExecCommand.set_code(code)
+  |> Kadena.Pact.ExecCommand.set_nonce(nonce)
+  |> Kadena.Pact.ExecCommand.set_data(env_data)
+  |> Kadena.Pact.ExecCommand.set_metadata(meta_data)
+  |> Kadena.Pact.ExecCommand.add_keypairs([keypair_1, keypair_2])
   |> Kadena.Pact.ExecCommand.add_signers(signers_list)
   |> Kadena.Pact.ExecCommand.build()
+
+# with a keyword list
+args = [
+  network_id: network_id,
+  code: code,
+  data: env_data,
+  nonce: nonce,
+  meta_data: meta_data,
+  keypairs: keypairs, #KeyPair list
+  signers: signers #SignersList struct
+]
+
+Kadena.Pact.ExecCommand.new(args)
+```
+
+### Continuation Command
+
+To create a continuation command is needed:
+
+- [NetworkID](#networkid)
+- [Nonce](#nonce)
+- [EnvData](#envdata) (optional)
+- [MetaData](#metadata)
+- [KeyPairs](#keypair)
+- [Signers](#signerslist) / [Signer](#signer)
+- [Step](#step)
+- [Proof](#proof) (optional)
+- [Rollback](#rollback)
+- [PactId](#pactid)
+
+The following examples shows how to create a continuation command:
+
+```elixir
+# with a single KeyPair and Signer
+Kadena.Pact.ContCommand.new()
+  |> Kadena.Pact.ContCommand.set_network(network_id)
+  |> Kadena.Pact.ContCommand.set_data(env_data)
+  |> Kadena.Pact.ContCommand.set_nonce(nonce)
+  |> Kadena.Pact.ContCommand.set_metadata(meta_data)
+  |> Kadena.Pact.ContCommand.add_keypair(keypair)
+  |> Kadena.Pact.ContCommand.add_signer(signer)
+  |> Kadena.Pact.ContCommand.set_pact_tx_hash(pact_id)
+  |> Kadena.Pact.ContCommand.set_step(step)
+  |> Kadena.Pact.ContCommand.set_rollback(rollback)
+  |> Kadena.Pact.ContCommand.build()
+
+# with a list of KeyPair and a SignersList
+Kadena.Pact.ContCommand.new()
+  |> Kadena.Pact.ContCommand.set_network(network_id)
+  |> Kadena.Pact.ContCommand.set_data(env_data)
+  |> Kadena.Pact.ContCommand.set_nonce(nonce)
+  |> Kadena.Pact.ContCommand.set_metadata(meta_data)
+  |> Kadena.Pact.ContCommand.add_keypairs([keypair_1, keypair_2])
+  |> Kadena.Pact.ContCommand.add_signers(signers_list)
+  |> Kadena.Pact.ContCommand.set_pact_tx_hash(pact_id)
+  |> Kadena.Pact.ContCommand.set_step(step)
+  |> Kadena.Pact.ContCommand.set_rollback(rollback)
+  |> Kadena.Pact.ContCommand.build()
+
+# with a keyword list
+args = [
+  network_id: network_id,
+  data: emv_data,
+  nonce: nonce,
+  meta_data: meta_data,
+  pact_tx_hash: pact_id,
+  step: step,
+  proof: proof,
+  rollback: rollback,
+  keypairs: keypairs, #KeyPair list
+  signers: signers #SignersList struct
+]
+
+Kadena.Pact.ExecCommand.new(args)
+
 ```
 
 #### NetworkID
@@ -113,11 +200,30 @@ There are three options allowed to set a NetworkID:
 
 #### Code
 
-String value that represents the Pact code to execute in the `Execution Command`.
+A String value that represents the Pact code to execute in the `Execution Command`.
 
 #### Nonce
 
-String value to ensure unique hash. You can use current timestamp.
+A String value to ensure unique hash. You can use current timestamp.
+
+#### Step
+
+The step is an Integer of the multi-step transaction.
+
+#### Proof
+
+A String SPV proof, required for cross-chain transfer.
+
+#### Rollback
+
+A Boolean that indicates if the continuation is:
+
+- rollback `true`
+- cancel `false`
+
+#### PactId
+
+Pact transaction id as a String.
 
 #### EnvData
 
@@ -163,7 +269,6 @@ secret_key = "secret_key_value"
 {:ok, %Kadena.Types.KeyPair{} = keypair} = Kadena.Cryptography.KeyPair.from_secret_key(secret_key)
 ```
 
-
 **KeyPairs with Capabilites**
 
 Creating a keypair with capabilities:
@@ -181,10 +286,11 @@ keypair_values = [
   clist: clist
 ]
 
-Kadena.Types.KeyPair.new(keypair_values)
+keypair = Kadena.Types.KeyPair.new(keypair_values)
 ```
 
 Adding capabilities to existing keypair:
+
 ```elixir
 clist =
   Kadena.Types.CapsList.new([
@@ -199,20 +305,30 @@ secret_key = "secret_key_value"
 keypair_with_clist = Kadena.Types.KeyPair.add_caps(keypair, clist)
 ```
 
+#### Signer
+
+Creating a signer:
+
+```elixir
+signer = Kadena.Types.Signer.new([pub_key: "pub_key"])
+```
+
 #### SignersList
 
 There are two ways to create a list of signers:
 
 ```elixir
-# with Keywords
+# with keyword list
 signer1 = [pub_key: "pub_key_1"]
 signer2 = [pub_key: "pub_key_2"]
+
+signers = Kadena.Types.SignersList.new([signer1, signer2])
 
 # with Signer structs
 signer1 = Kadena.Types.Signer.new([pub_key: "pub_key_1"])
 signer2 = Kadena.Types.Signer.new([pub_key: "pub_key_2"])
 
-Kadena.Types.SignersList.new([signer1, signer2])
+signers = Kadena.Types.SignersList.new([signer1, signer2])
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,15 +6,14 @@
 ![Downloads Badge](https://img.shields.io/hexpm/dt/kadena?style=for-the-badge)
 [![License badge](https://img.shields.io/hexpm/l/kadena?style=for-the-badge)](https://github.com/kommitters/kadena.ex/blob/main/LICENSE)
 
-**Kadena.ex** is an open source library for Elixir that allows developers to interact with the Kadena Chainweb.
+**Kadena.ex** is an open source library for Elixir that allows developers to interact with Kadena Chainweb.
 
 ## What can you do with Kadena.ex?
 
-- Construct commands for transactions.
-- Implement cryptography required by the network.
-- Interacting with public network endpoints:
-  - listen, local, poll, send, spv, cut.
-- Send, test and update smart contracts on the network.
+- Build PACT commands for transactions.
+- Implement the cryptography required by the network.
+- Send, test and update smart contracts.
+- Interact with Chainweb endpoints: `listen, local, poll, send, spv.`
 
 ## Installation
 
@@ -27,6 +26,390 @@ def deps do
   ]
 end
 ```
+
+## Configuration
+
+The default HTTP Client is `:hackney`. Options can be passed to `:hackney` via configuration parameters.
+```elixir
+config :kadena, hackney_opts: [{:connect_timeout, 1000}, {:recv_timeout, 5000}]
+```
+
+### Custom HTTP Client
+`kadena.ex` allows you to use the HTTP client of your choice. See [**Kadena.Chainweb.Client.Spec**][http_client_spec] for details.
+
+```elixir
+config :kadena, :http_client_impl, YourApp.CustomClientImpl
+```
+
+### Custom JSON library
+Following the same approach as the HTTP client, the JSON parsing library can also be configured. Defaults to [`Jason`][jason_url].
+
+```elixir
+config :kadena, :json_library, YourApp.CustomJSONLibrary
+```
+
+## Keypairs
+Curve25519 keypair of (PUBLIC,SECRET) match. Key values are base-16 strings of length 32.
+
+### Generate a KeyPair
+
+```elixir
+alias Kadena.Cryptography.KeyPair
+
+# generate a random keypair
+{:ok, keypair} = KeyPair.generate()
+
+{:ok,
+ %Kadena.Types.KeyPair{
+   clist: %Kadena.Types.OptionalCapsList{clist: nil},
+   pub_key: "37e60c00779cacaef1f0a8697387a5945ef3cb82963980db486dc26ec5f424d9",
+   secret_key: "e53faf1774d30e7cec2878d2e4a617c34045f53f0579eb05e127a7808aac229d"
+ }}
+```
+
+### Derive a keyPair from a secret key
+```elixir
+{:ok, keypair} = KeyPair.from_secret_key("e53faf1774d30e7cec2878d2e4a617c34045f53f0579eb05e127a7808aac229d")
+
+{:ok,
+ %Kadena.Types.KeyPair{
+   clist: %Kadena.Types.OptionalCapsList{clist: nil},
+   pub_key: "37e60c00779cacaef1f0a8697387a5945ef3cb82963980db486dc26ec5f424d9",
+   secret_key: "e53faf1774d30e7cec2878d2e4a617c34045f53f0579eb05e127a7808aac229d"
+ }}
+```
+
+### Adding capabilities to a KeyPair
+
+```elixir
+alias Kadena.Cryptography.KeyPair
+alias Kadena.Types.CapsList
+
+{:ok, keypair} = KeyPair.from_secret_key("e53faf1774d30e7cec2878d2e4a617c34045f53f0579eb05e127a7808aac229d")
+
+clist = Kadena.Types.CapsList.new([
+    [name: "coin.GAS", args: [keypair.pub_key]]
+  ])
+
+keypair_with_caps = Kadena.Types.KeyPair.add_caps(keypair, clist)
+
+%Kadena.Types.KeyPair{
+  clist: %Kadena.Types.OptionalCapsList{
+    clist: %Kadena.Types.CapsList{
+      caps: [
+        %Kadena.Types.Cap{
+          args: %Kadena.Types.PactValuesList{
+            pact_values: [
+              %Kadena.Types.PactValue{
+                literal: "37e60c00779cacaef1f0a8697387a5945ef3cb82963980db486dc26ec5f424d9"
+              }
+            ]
+          },
+          name: "coin.GAS"
+        }
+      ]
+    }
+  },
+  pub_key: "37e60c00779cacaef1f0a8697387a5945ef3cb82963980db486dc26ec5f424d9",
+  secret_key: "e53faf1774d30e7cec2878d2e4a617c34045f53f0579eb05e127a7808aac229d"
+}
+```
+
+## PACT Commands
+
+`kadena.ex` allows the construction of **execution** and **continuation** commands in a semantic way for developers.
+
+```elixir
+alias Kadena.Cryptography.KeyPair
+alias Kadena.Types.Command
+alias Kadena.Pact
+
+{:ok, keypair} = KeyPair.generate()
+
+code = "(+ 1 2)"
+
+{:ok, %Command{} = command} =
+  Pact.ExecCommand.new()
+  |> Pact.ExecCommand.set_code(code)
+  |> Pact.ExecCommand.add_keypair(keypair)
+  |> Pact.ExecCommand.build()
+```
+
+### Attributes
+
+#### NetworkID
+Backend-specific identifier of target network. Allowed values: `:testnet04` `:mainnet01` `:development`.
+
+```elixir
+alias Kadena.Pact
+
+network_id = :testnet04
+
+Pact.ExecCommand.new() |> Pact.ExecCommand.set_network(network_id)
+```
+
+#### Code
+Executable PACT code.
+
+```elixir
+alias Kadena.Pact
+
+code = "(+ 1 2)"
+
+Pact.ExecCommand.new() |> Pact.ExecCommand.set_code(code)
+```
+
+#### Metadata
+Public metadata for Chainweb.
+
+```elixir
+alias Kadena.Pact
+
+metadata = Kadena.Types.MetaData.new(
+    creation_time: 1_667_249_173,
+    ttl: 28_800,
+    gas_limit: 1000,
+    gas_price: 0.01,
+    sender: "k:37e60c00779cacaef1f0a8697387a5945ef3cb82963980db486dc26ec5f424d9",
+    chain_id: "0"
+  )
+
+Pact.ExecCommand.new() |> Pact.ExecCommand.set_metadata(metadata)
+```
+
+#### Nonce
+An arbitrary user-supplied value. Defaults to current timestamp.
+
+```elixir
+alias Kadena.Pact
+
+nonce = "2023-01-01 00:00:00.000000 UTC"
+
+Pact.ExecCommand.new() |> Pact.ExecCommand.set_nonce(data)
+```
+
+#### EnvData
+Environment transaction data.
+
+```elixir
+alias Kadena.Pact
+
+env_data = %{
+    accounts_admin_keyset: [
+      "ba54b224d1924dd98403f5c751abdd10de6cd81b0121800bf7bdbdcfaec7388d"
+    ]
+  }
+
+Pact.ExecCommand.new() |> Pact.ExecCommand.set_data(data)
+```
+
+#### KeyPairs
+List of KeyPairs for signing.
+
+```elixir
+alias Kadena.Pact
+alias Kadena.Cryptography.KeyPair
+
+{:ok, keypair1} = KeyPair.generate()
+{:ok, keypair2} = KeyPair.generate()
+
+# add a list of keypairs
+Pact.ExecCommand.new() |> Pact.ExecCommand.add_keypairs([keypair1, keypair2])
+
+# add a single keypair
+Pact.ExecCommand.new() |> Pact.ExecCommand.add_keypair(keypair1)
+```
+
+#### Signers
+List of signers for detached signatures.
+
+```elixir
+alias Kadena.Pact
+
+signer1 = Kadena.Types.Signer.new(pub_key: "37e60c00779cacaef1f0a8697387a5945ef3cb82963980db486dc26ec5f424d9")
+signer2 = Kadena.Types.Signer.new(pub_key: "8567032f1fe8b99c657338cd46480d0ee1a86985626b16374099d8d406e4d313")
+
+# add a list of signers
+Pact.ExecCommand.new() |> Pact.ExecCommand.add_signers([signer1, signer2])
+
+# add a single signer
+Pact.ExecCommand.new() |> Pact.ExecCommand.add_signer(signer1)
+```
+
+#### Step (Continuation command)
+
+An integer value for the multi-step transaction.
+
+```elixir
+alias Kadena.Pact
+
+step = 1
+
+Pact.ContCommand.new() |> Pact.ContCommand.set_step(step)
+```
+
+#### Proof (Continuation command)
+
+A SPV proof, required for cross-chain transfer.
+
+```elixir
+alias Kadena.Pact
+
+proof = "proof"
+
+Pact.ContCommand.new() |> Pact.ContCommand.set_proof(proof)
+```
+
+#### Rollback (Continuation command)
+
+A Boolean that indicates if the continuation is:
+
+- rollback `true`
+- cancel `false`
+
+```elixir
+alias Kadena.Pact
+
+rollback = true
+
+Pact.ContCommand.new() |> Pact.ContCommand.set_rollback(rollback)
+```
+
+#### PactTxHash (Continuation command)
+
+Continuation transaction hash.
+
+```elixir
+alias Kadena.Pact
+
+pact_tx_hash = "yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4"
+
+Pact.ContCommand.new() |> Pact.ContCommand.set_pact_tx_hash(pact_tx_hash)
+```
+
+### Building an Execution Command
+
+```elixir
+alias Kadena.Cryptography
+alias Kadena.Pact
+
+# set the command attributes
+{:ok, raw_keypair} = Cryptography.KeyPair.from_secret_key("99f7e1e8f2f334ae8374aa28bebdb997271a0e0a5e92c80be9609684a3d6f0d4")
+
+caps = Kadena.Types.CapsList.new([
+    [name: "coin.GAS", args: [raw_keypair.pub_key]]
+  ])
+
+keypair = Kadena.Types.KeyPair.add_caps(raw_keypair, caps)
+
+network_id = :testnet04
+
+code = "(+ 1 2)"
+
+metadata = Kadena.Types.MetaData.new(
+    creation_time: 1_667_249_173,
+    ttl: 28_800,
+    gas_limit: 2500,
+    gas_price: 0.01,
+    sender: "k:#{keypair.pub_key}",
+    chain_id: "0"
+  )
+
+nonce = "2023-01-01 00:00:00.000000 UTC"
+
+env_data = %{accounts_admin_keyset: [keypair.pub_key]}
+
+# build the command
+{:ok, %Kadena.Types.Command{} = command} =
+  Pact.ExecCommand.new()
+  |> Pact.ExecCommand.set_network(network_id)
+  |> Pact.ExecCommand.set_code(code)
+  |> Pact.ExecCommand.set_nonce(nonce)
+  |> Pact.ExecCommand.set_data(env_data)
+  |> Pact.ExecCommand.set_metadata(metadata)
+  |> Pact.ExecCommand.add_keypair(keypair)
+  |> Pact.ExecCommand.build()
+
+{:ok, %Kadena.Types.Command{
+  cmd: "{\"meta\":{\"chainId\":\"0\",\"creationTime\":1667249173,\"gasLimit\":2500,\"gasPrice\":0.01,\"sender\":\"k:6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"ttl\":28800},\"networkId\":\"testnet04\",\"nonce\":\"2023-01-01 00:00:00.000000 UTC\",\"payload\":{\"exec\":{\"code\":\"(+ 1 2)\",\"data\":{\"accounts-admin-keyset\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"]}}},\"signers\":[{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"}]}",
+  hash: %Kadena.Types.PactTransactionHash{
+    hash: "TAGG_ar-gxdeOhyYAJyF4ZtTwV7_3UGHZMUzRB2nVfY"
+  },
+  sigs: %Kadena.Types.SignaturesList{
+    signatures: [
+      %Kadena.Types.Signature{
+        sig: "5f4ce544aef7c439d97720c12eb8996f013d966abdf754dc6b0d353196fc962781ed5a9b982d9b7156bcd4bf19c868053c64e7fb1ad5edf695bfbd8a3225e304"
+      }
+    ]
+  }
+}}
+```
+
+### Building a Continuation Command
+
+```elixir
+alias Kadena.Cryptography
+alias Kadena.Pact
+
+# set the command attributes
+{:ok, raw_keypair} = Cryptography.KeyPair.from_secret_key("99f7e1e8f2f334ae8374aa28bebdb997271a0e0a5e92c80be9609684a3d6f0d4")
+
+caps = Kadena.Types.CapsList.new([
+    [name: "coin.GAS", args: [raw_keypair.pub_key]]
+  ])
+
+keypair = Kadena.Types.KeyPair.add_caps(raw_keypair, caps)
+
+network_id = :testnet04
+
+metadata = Kadena.Types.MetaData.new(
+    creation_time: 1_667_249_173,
+    ttl: 28_800,
+    gas_limit: 2500,
+    gas_price: 0.01,
+    sender: "k:#{keypair.pub_key}",
+    chain_id: "0"
+  )
+
+nonce = "2023-01-01 00:00:00.000000 UTC"
+
+env_data = %{accounts_admin_keyset: [keypair.pub_key]}
+
+pact_tx_hash = "yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4"
+
+step = 1
+
+rollback = true
+
+# build the command
+{:ok, %Kadena.Types.Command{} = command} =
+  Pact.ContCommand.new()
+  |> Pact.ContCommand.set_network(network_id)
+  |> Pact.ContCommand.set_data(env_data)
+  |> Pact.ContCommand.set_nonce(nonce)
+  |> Pact.ContCommand.set_metadata(metadata)
+  |> Pact.ContCommand.add_keypair(keypair)
+  |> Pact.ContCommand.set_pact_tx_hash(pact_tx_hash)
+  |> Pact.ContCommand.set_step(step)
+  |> Pact.ContCommand.set_rollback(rollback)
+  |> Pact.ContCommand.build()
+
+{:ok, %Kadena.Types.Command{
+  cmd: "{\"meta\":{\"chainId\":\"0\",\"creationTime\":1667249173,\"gasLimit\":2500,\"gasPrice\":0.01,\"sender\":\"k:6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"ttl\":28800},\"networkId\":\"testnet04\",\"nonce\":\"2023-01-01 00:00:00.000000 UTC\",\"payload\":{\"cont\":{\"data\":{\"accounts-admin-keyset\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"]},\"pactId\":\"yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4\",\"proof\":null,\"rollback\":true,\"step\":1}},\"signers\":[{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"}]}",
+  hash: %Kadena.Types.PactTransactionHash{
+    hash: "teDAH5S3H0DgzYWL-NKOTA-D2sIT01hDYHxpKRZv6zc"
+  },
+  sigs: %Kadena.Types.SignaturesList{
+    signatures: [
+      %Kadena.Types.Signature{
+        sig: "708777a672ebf3f29d936a75677305a2a77add7380abede734696dddc4cbbfd62d8cfc1e236e7a8e1df07632233a05c697157ef7a58fcf67a91d6c4791ca7807"
+      }
+    ]
+  }
+}}
+```
+
+---
 
 ## Roadmap
 
@@ -64,272 +447,6 @@ You can see a big picture of the roadmap here: [**ROADMAP**][roadmap]
 - [Pact Commands Builder](https://github.com/kommitters/kadena.ex/issues/131)
 
 </details>
-
----
-
-## Building Commands
-
-This library allows to build command payloads in a composable and semantic manner.
-These commands are intended to be used as the request body to the Pact API endpoints.
-
-There are two type of commands:
-
-- [`Execution`](#execution-command)
-- [`Continuation`](#continuation-command)
-
-### Execution Command
-
-To create an execution command is needed:
-
-- [NetworkID](#networkid)
-- [Code](#code)
-- [Nonce](#nonce)
-- [EnvData](#envdata) (optional)
-- [MetaData](#metadata)
-- [KeyPairs](#keypair)
-- [Signers](#signerslist) / [Signer](#signer)
-
-The following examples shows how to create an execution command:
-
-```elixir
-# with a single KeyPair and Signer
-Kadena.Pact.ExecCommand.new()
-  |> Kadena.Pact.ExecCommand.set_network(network_id)
-  |> Kadena.Pact.ExecCommand.set_code(code)
-  |> Kadena.Pact.ExecCommand.set_nonce(nonce)
-  |> Kadena.Pact.ExecCommand.set_data(env_data)
-  |> Kadena.Pact.ExecCommand.set_metadata(meta_data)
-  |> Kadena.Pact.ExecCommand.add_keypair(keypair)
-  |> Kadena.Pact.ExecCommand.add_signer(signer)
-  |> Kadena.Pact.ExecCommand.build()
-
-# with a list of KeyPair and a SignersList
-Kadena.Pact.ExecCommand.new()
-  |> Kadena.Pact.ExecCommand.set_network(network_id)
-  |> Kadena.Pact.ExecCommand.set_code(code)
-  |> Kadena.Pact.ExecCommand.set_nonce(nonce)
-  |> Kadena.Pact.ExecCommand.set_data(env_data)
-  |> Kadena.Pact.ExecCommand.set_metadata(meta_data)
-  |> Kadena.Pact.ExecCommand.add_keypairs([keypair_1, keypair_2])
-  |> Kadena.Pact.ExecCommand.add_signers(signers_list)
-  |> Kadena.Pact.ExecCommand.build()
-
-# with a keyword list
-args = [
-  network_id: network_id,
-  code: code,
-  data: env_data,
-  nonce: nonce,
-  meta_data: meta_data,
-  keypairs: keypairs, #KeyPair list
-  signers: signers #SignersList struct
-]
-
-Kadena.Pact.ExecCommand.new(args)
-```
-
-### Continuation Command
-
-To create a continuation command is needed:
-
-- [NetworkID](#networkid)
-- [Nonce](#nonce)
-- [EnvData](#envdata) (optional)
-- [MetaData](#metadata)
-- [KeyPairs](#keypair)
-- [Signers](#signerslist) / [Signer](#signer)
-- [Step](#step)
-- [Proof](#proof) (optional)
-- [Rollback](#rollback)
-- [PactId](#pactid)
-
-The following examples shows how to create a continuation command:
-
-```elixir
-# with a single KeyPair and Signer
-Kadena.Pact.ContCommand.new()
-  |> Kadena.Pact.ContCommand.set_network(network_id)
-  |> Kadena.Pact.ContCommand.set_data(env_data)
-  |> Kadena.Pact.ContCommand.set_nonce(nonce)
-  |> Kadena.Pact.ContCommand.set_metadata(meta_data)
-  |> Kadena.Pact.ContCommand.add_keypair(keypair)
-  |> Kadena.Pact.ContCommand.add_signer(signer)
-  |> Kadena.Pact.ContCommand.set_pact_tx_hash(pact_id)
-  |> Kadena.Pact.ContCommand.set_step(step)
-  |> Kadena.Pact.ContCommand.set_rollback(rollback)
-  |> Kadena.Pact.ContCommand.build()
-
-# with a list of KeyPair and a SignersList
-Kadena.Pact.ContCommand.new()
-  |> Kadena.Pact.ContCommand.set_network(network_id)
-  |> Kadena.Pact.ContCommand.set_data(env_data)
-  |> Kadena.Pact.ContCommand.set_nonce(nonce)
-  |> Kadena.Pact.ContCommand.set_metadata(meta_data)
-  |> Kadena.Pact.ContCommand.add_keypairs([keypair_1, keypair_2])
-  |> Kadena.Pact.ContCommand.add_signers(signers_list)
-  |> Kadena.Pact.ContCommand.set_pact_tx_hash(pact_id)
-  |> Kadena.Pact.ContCommand.set_step(step)
-  |> Kadena.Pact.ContCommand.set_rollback(rollback)
-  |> Kadena.Pact.ContCommand.build()
-
-# with a keyword list
-args = [
-  network_id: network_id,
-  data: emv_data,
-  nonce: nonce,
-  meta_data: meta_data,
-  pact_tx_hash: pact_id,
-  step: step,
-  proof: proof,
-  rollback: rollback,
-  keypairs: keypairs, #KeyPair list
-  signers: signers #SignersList struct
-]
-
-Kadena.Pact.ExecCommand.new(args)
-
-```
-
-#### NetworkID
-
-There are three options allowed to set a NetworkID:
-
-- `:testnet04`
-- `:mainnet01`
-- `:development`
-
-#### Code
-
-A String value that represents the Pact code to execute in the `Execution Command`.
-
-#### Nonce
-
-A String value to ensure unique hash. You can use current timestamp.
-
-#### Step
-
-The step is an Integer of the multi-step transaction.
-
-#### Proof
-
-A String SPV proof, required for cross-chain transfer.
-
-#### Rollback
-
-A Boolean that indicates if the continuation is:
-
-- rollback `true`
-- cancel `false`
-
-#### PactId
-
-Pact transaction id as a String.
-
-#### EnvData
-
-A map must be provided to create an environment data, for example:
-
-```elixir
-data = %{
-  accounts_admin_keyset: [
-    "ba54b224d1924dd98403f5c751abdd10de6cd81b0121800bf7bdbdcfaec7388d"
-  ]
-}
-
-Kadena.Types.EnvData.new(data)
-```
-
-#### MetaData
-
-To create a MetaData:
-
-```elixir
-raw_metadata = [
-  creation_time: 0,
-  ttl: 0,
-  gas_limit: 2500,
-  gas_price: 1.0e-2,
-  sender: "account_name",
-  chain_id: "0"
-]
-
-Kadena.Types.MetaData.new(raw_metadata)
-```
-
-#### KeyPairs
-
-There are two ways to get a keypair:
-
-```elixir
-# generate a random keypair
-{:ok, %Kadena.Types.KeyPair{} = keypair} = Kadena.Cryptography.KeyPair.generate()
-
-# derive a keypair from a secret key
-secret_key = "secret_key_value"
-{:ok, %Kadena.Types.KeyPair{} = keypair} = Kadena.Cryptography.KeyPair.from_secret_key(secret_key)
-```
-
-**KeyPairs with Capabilites**
-
-Creating a keypair with capabilities:
-
-```elixir
-clist =
-  Kadena.Types.CapsList.new([
-    [name: "gas", args: ["COIN.gas", 0.02]],
-    [name: "transfer", args: ["COIN.transfer", "key_1", 50, "key_2"]]
-  ])
-
-keypair_values = [
-  pub_key: "pub_key_value",
-  secret_key: "secret_key_value",
-  clist: clist
-]
-
-keypair = Kadena.Types.KeyPair.new(keypair_values)
-```
-
-Adding capabilities to existing keypair:
-
-```elixir
-clist =
-  Kadena.Types.CapsList.new([
-    [name: "gas", args: ["COIN.gas", 0.02]],
-    [name: "transfer", args: ["COIN.transfer", "key_1", 50, "key_2"]]
-  ])
-
-
-secret_key = "secret_key_value"
-{:ok, %Kadena.Types.KeyPair{} = keypair} = Kadena.Cryptography.KeyPair.from_secret_key(secret_key)
-
-keypair_with_clist = Kadena.Types.KeyPair.add_caps(keypair, clist)
-```
-
-#### Signer
-
-Creating a signer:
-
-```elixir
-signer = Kadena.Types.Signer.new([pub_key: "pub_key"])
-```
-
-#### SignersList
-
-There are two ways to create a list of signers:
-
-```elixir
-# with keyword list
-signer1 = [pub_key: "pub_key_1"]
-signer2 = [pub_key: "pub_key_2"]
-
-signers = Kadena.Types.SignersList.new([signer1, signer2])
-
-# with Signer structs
-signer1 = Kadena.Types.Signer.new([pub_key: "pub_key_1"])
-signer2 = Kadena.Types.Signer.new([pub_key: "pub_key_2"])
-
-signers = Kadena.Types.SignersList.new([signer1, signer2])
-```
 
 ---
 
@@ -371,3 +488,5 @@ Made with 💙 by [kommitters Open Source](https://kommit.co)
 [contributing]: https://github.com/kommitters/kadena.ex/blob/main/CONTRIBUTING.md
 [roadmap]: https://github.com/orgs/kommitters/projects/5/views/3
 [good-first-issues]: https://github.com/kommitters/kadena.ex/labels/%F0%9F%91%8B%20Good%20first%20issue
+[http_client_spec]: https://github.com/kommitters/kadena.ex/blob/main/lib/chainweb/client/spec.ex
+[jason_url]: https://github.com/michalmuskala/jason

--- a/lib/chainweb/pact/request.ex
+++ b/lib/chainweb/pact/request.ex
@@ -5,14 +5,17 @@ defmodule Kadena.Chainweb.Pact.Request do
 
   alias Kadena.Types.{
     ListenRequestBody,
-    ListenResponse,
     LocalRequestBody,
-    LocalResponse,
     PollRequestBody,
-    PollResponse,
     SendRequestBody,
+    SPVRequestBody
+  }
+
+  alias Kadena.Chainweb.Types.{
+    ListenResponse,
+    LocalResponse,
+    PollResponse,
     SendResponse,
-    SPVRequestBody,
     SPVResponse
   }
 

--- a/lib/chainweb/types/command_result.ex
+++ b/lib/chainweb/types/command_result.ex
@@ -1,4 +1,4 @@
-defmodule Kadena.Types.CommandResult do
+defmodule Kadena.Chainweb.Types.CommandResult do
   @moduledoc """
   `CommandResult` struct definition.
   """

--- a/lib/chainweb/types/listen_response.ex
+++ b/lib/chainweb/types/listen_response.ex
@@ -1,4 +1,4 @@
-defmodule Kadena.Types.ListenResponse do
+defmodule Kadena.Chainweb.Types.ListenResponse do
   @moduledoc """
   `ListenResponse` struct definition.
   """
@@ -6,11 +6,12 @@ defmodule Kadena.Types.ListenResponse do
   alias Kadena.Types.{
     Base64Url,
     ChainwebResponseMetaData,
-    CommandResult,
     OptionalPactEventsList,
     PactExec,
     PactResult
   }
+
+  alias Kadena.Chainweb.Types.CommandResult
 
   @behaviour Kadena.Types.Spec
 

--- a/lib/chainweb/types/local_response.ex
+++ b/lib/chainweb/types/local_response.ex
@@ -1,4 +1,4 @@
-defmodule Kadena.Types.LocalResponse do
+defmodule Kadena.Chainweb.Types.LocalResponse do
   @moduledoc """
   `LocalResponse` struct definition.
   """
@@ -6,11 +6,12 @@ defmodule Kadena.Types.LocalResponse do
   alias Kadena.Types.{
     Base64Url,
     ChainwebResponseMetaData,
-    CommandResult,
     OptionalPactEventsList,
     PactExec,
     PactResult
   }
+
+  alias Kadena.Chainweb.Types.CommandResult
 
   @behaviour Kadena.Types.Spec
 

--- a/lib/chainweb/types/poll_response.ex
+++ b/lib/chainweb/types/poll_response.ex
@@ -1,9 +1,10 @@
-defmodule Kadena.Types.PollResponse do
+defmodule Kadena.Chainweb.Types.PollResponse do
   @moduledoc """
   `PollResponse` struct definition.
   """
 
-  alias Kadena.Types.{Base64Url, CommandResult}
+  alias Kadena.Chainweb.Types.CommandResult
+  alias Kadena.Types.Base64Url
 
   @behaviour Kadena.Types.Spec
 

--- a/lib/chainweb/types/send_response.ex
+++ b/lib/chainweb/types/send_response.ex
@@ -1,4 +1,4 @@
-defmodule Kadena.Types.SendResponse do
+defmodule Kadena.Chainweb.Types.SendResponse do
   @moduledoc """
   `SendResponse` struct definition.
   """

--- a/lib/chainweb/types/spv_response.ex
+++ b/lib/chainweb/types/spv_response.ex
@@ -1,4 +1,4 @@
-defmodule Kadena.Types.SPVResponse do
+defmodule Kadena.Chainweb.Types.SPVResponse do
   @moduledoc """
   `SPVResponse` struct definition.
   """

--- a/lib/pact/command/hash.ex
+++ b/lib/pact/command/hash.ex
@@ -1,0 +1,23 @@
+defmodule Kadena.Pact.Command.Hash do
+  @moduledoc """
+    Specifies function that checks if all the sign commands hashes are the same
+  """
+  alias Kadena.Types.SignCommand
+
+  @type hash :: String.t()
+  @type sign_command :: SignCommand.t()
+  @type sign_commands :: list(sign_command())
+  @type valid_hash :: {:ok, hash()}
+
+  @spec pull_unique(sign_commands()) :: valid_hash()
+  def pull_unique(sign_commands) do
+    unique_hash =
+      Enum.reduce(sign_commands, nil, fn %SignCommand{hash: hash}, acc ->
+        if is_nil(acc) or acc == hash,
+          do: hash,
+          else: {:error, [hash: :not_unique]}
+      end)
+
+    {:ok, unique_hash}
+  end
+end

--- a/lib/types/command_payload.ex
+++ b/lib/types/command_payload.ex
@@ -194,7 +194,7 @@ defmodule Kadena.Types.CommandPayload do
           data: extract_data(data),
           pact_id: hash,
           proof: extract_proof(proof),
-          roollback: rollback,
+          rollback: rollback,
           step: number
         }
       }

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Kadena.MixProject do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.9.0"
   @github_url "https://github.com/kommitters/kadena.ex"
 
   def project do
@@ -85,7 +85,9 @@ defmodule Kadena.MixProject do
     [
       "Building Commands": [
         Kadena.Pact.Command,
-        Kadena.Pact.ExecCommand
+        Kadena.Pact.Command.Hash,
+        Kadena.Pact.ExecCommand,
+        Kadena.Pact.ContCommand
       ],
       "Kadena Chainweb": [
         Kadena.Chainweb.Client,

--- a/mix.exs
+++ b/mix.exs
@@ -118,7 +118,6 @@ defmodule Kadena.MixProject do
         Kadena.Types.ChainwebResponseMetaData,
         Kadena.Types.Command,
         Kadena.Types.CommandPayload,
-        Kadena.Types.CommandResult,
         Kadena.Types.CommandsList,
         Kadena.Types.ContPayload,
         Kadena.Types.Continuation,
@@ -126,9 +125,7 @@ defmodule Kadena.MixProject do
         Kadena.Types.ExecPayload,
         Kadena.Types.KeyPair,
         Kadena.Types.ListenRequestBody,
-        Kadena.Types.ListenResponse,
         Kadena.Types.LocalRequestBody,
-        Kadena.Types.LocalResponse,
         Kadena.Types.MetaData,
         Kadena.Types.NetworkID,
         Kadena.Types.OptionalCapsList,
@@ -147,12 +144,10 @@ defmodule Kadena.MixProject do
         Kadena.Types.PactValue,
         Kadena.Types.PactValuesList,
         Kadena.Types.PollRequestBody,
-        Kadena.Types.PollResponse,
         Kadena.Types.Proof,
         Kadena.Types.Provenance,
         Kadena.Types.Rollback,
         Kadena.Types.SendRequestBody,
-        Kadena.Types.SendResponse,
         Kadena.Types.SignCommand,
         Kadena.Types.SignatureWithHash,
         Kadena.Types.Signature,
@@ -164,9 +159,16 @@ defmodule Kadena.MixProject do
         Kadena.Types.Spec,
         Kadena.Types.SPVProof,
         Kadena.Types.SPVRequestBody,
-        Kadena.Types.SPVResponse,
         Kadena.Types.Step,
         Kadena.Types.Yield
+      ],
+      "Chainweb Types": [
+        Kadena.Chainweb.Types.CommandResult,
+        Kadena.Chainweb.Types.ListenResponse,
+        Kadena.Chainweb.Types.LocalResponse,
+        Kadena.Chainweb.Types.PollResponse,
+        Kadena.Chainweb.Types.SendResponse,
+        Kadena.Chainweb.Types.SPVResponse
       ],
       Utils: Kadena.Utils.MapCase
     ]

--- a/test/chainweb/types/command_result_test.exs
+++ b/test/chainweb/types/command_result_test.exs
@@ -1,6 +1,6 @@
-defmodule Kadena.Types.ListenResponseTest do
+defmodule Kadena.Chainweb.Types.CommandResultTest do
   @moduledoc """
-  `ListenResponse` struct definition tests.
+  `CommandResult` struct definition tests.
   """
 
   use ExUnit.Case
@@ -8,14 +8,16 @@ defmodule Kadena.Types.ListenResponseTest do
   alias Kadena.Types.{
     Base64Url,
     ChainwebResponseMetaData,
+    CommandResult,
     Continuation,
-    ListenResponse,
     OptionalPactEventsList,
     PactEventsList,
     PactExec,
     PactResult,
     Yield
   }
+
+  alias Kadena.Chainweb.Types.CommandResult
 
   describe "new/1" do
     setup do
@@ -95,7 +97,7 @@ defmodule Kadena.Types.ListenResponseTest do
       events_value: events_value,
       events: events
     } do
-      %ListenResponse{
+      %CommandResult{
         req_key: %Base64Url{url: ^req_key},
         tx_id: ^tx_id,
         result: ^result,
@@ -105,7 +107,7 @@ defmodule Kadena.Types.ListenResponseTest do
         meta_data: ^meta_data,
         events: %OptionalPactEventsList{pact_events: ^events}
       } =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result_value,
@@ -127,7 +129,7 @@ defmodule Kadena.Types.ListenResponseTest do
       meta_data: meta_data,
       events: events
     } do
-      %ListenResponse{
+      %CommandResult{
         req_key: %Base64Url{url: ^req_key},
         tx_id: ^tx_id,
         result: ^result,
@@ -137,7 +139,7 @@ defmodule Kadena.Types.ListenResponseTest do
         meta_data: ^meta_data,
         events: %OptionalPactEventsList{pact_events: ^events}
       } =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -155,7 +157,7 @@ defmodule Kadena.Types.ListenResponseTest do
       gas: gas,
       continuation: continuation
     } do
-      %ListenResponse{
+      %CommandResult{
         req_key: %Base64Url{url: ^req_key},
         tx_id: nil,
         result: ^result,
@@ -165,7 +167,7 @@ defmodule Kadena.Types.ListenResponseTest do
         meta_data: nil,
         events: %OptionalPactEventsList{pact_events: nil}
       } =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: nil,
           result: result,
@@ -187,7 +189,7 @@ defmodule Kadena.Types.ListenResponseTest do
       events: events
     } do
       {:error, [req_key: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: :invalid,
           tx_id: tx_id,
           result: result,
@@ -209,7 +211,7 @@ defmodule Kadena.Types.ListenResponseTest do
       events: events
     } do
       {:error, [tx_id: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: "invalid",
           result: result,
@@ -231,7 +233,7 @@ defmodule Kadena.Types.ListenResponseTest do
       events: events
     } do
       {:error, [result: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: "invalid",
@@ -253,7 +255,7 @@ defmodule Kadena.Types.ListenResponseTest do
       events: events
     } do
       {:error, [result: :invalid, status: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: [status: :invalid_status, result: 3],
@@ -275,7 +277,7 @@ defmodule Kadena.Types.ListenResponseTest do
       events: events
     } do
       {:error, [gas: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -297,7 +299,7 @@ defmodule Kadena.Types.ListenResponseTest do
       events: events
     } do
       {:error, [logs: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -319,7 +321,7 @@ defmodule Kadena.Types.ListenResponseTest do
       events: events
     } do
       {:error, [continuation: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -341,7 +343,7 @@ defmodule Kadena.Types.ListenResponseTest do
       events: events
     } do
       {:error, [continuation: :invalid, pact_id: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -363,7 +365,7 @@ defmodule Kadena.Types.ListenResponseTest do
       events: events
     } do
       {:error, [meta_data: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -385,7 +387,7 @@ defmodule Kadena.Types.ListenResponseTest do
       events: events
     } do
       {:error, [meta_data: :invalid, block_hash: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -407,7 +409,7 @@ defmodule Kadena.Types.ListenResponseTest do
       meta_data: meta_data
     } do
       {:error, [events: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -429,7 +431,7 @@ defmodule Kadena.Types.ListenResponseTest do
       meta_data: meta_data
     } do
       {:error, [events: :invalid, pact_events: :invalid, name: :invalid]} =
-        ListenResponse.new(
+        CommandResult.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -439,10 +441,6 @@ defmodule Kadena.Types.ListenResponseTest do
           meta_data: meta_data,
           events: [[name: :invalid_value]]
         )
-    end
-
-    test "with an invalid list" do
-      {:error, [listen_response: :not_a_list]} = ListenResponse.new("no list")
     end
   end
 end

--- a/test/chainweb/types/listen_response_test.exs
+++ b/test/chainweb/types/listen_response_test.exs
@@ -1,6 +1,6 @@
-defmodule Kadena.Types.LocalResponseTest do
+defmodule Kadena.Chainweb.Types.ListenResponseTest do
   @moduledoc """
-  `LocalResponse` struct definition tests.
+  `ListenResponse` struct definition tests.
   """
 
   use ExUnit.Case
@@ -9,13 +9,14 @@ defmodule Kadena.Types.LocalResponseTest do
     Base64Url,
     ChainwebResponseMetaData,
     Continuation,
-    LocalResponse,
     OptionalPactEventsList,
     PactEventsList,
     PactExec,
     PactResult,
     Yield
   }
+
+  alias Kadena.Chainweb.Types.ListenResponse
 
   describe "new/1" do
     setup do
@@ -95,7 +96,7 @@ defmodule Kadena.Types.LocalResponseTest do
       events_value: events_value,
       events: events
     } do
-      %LocalResponse{
+      %ListenResponse{
         req_key: %Base64Url{url: ^req_key},
         tx_id: ^tx_id,
         result: ^result,
@@ -105,7 +106,7 @@ defmodule Kadena.Types.LocalResponseTest do
         meta_data: ^meta_data,
         events: %OptionalPactEventsList{pact_events: ^events}
       } =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result_value,
@@ -127,7 +128,7 @@ defmodule Kadena.Types.LocalResponseTest do
       meta_data: meta_data,
       events: events
     } do
-      %LocalResponse{
+      %ListenResponse{
         req_key: %Base64Url{url: ^req_key},
         tx_id: ^tx_id,
         result: ^result,
@@ -137,7 +138,7 @@ defmodule Kadena.Types.LocalResponseTest do
         meta_data: ^meta_data,
         events: %OptionalPactEventsList{pact_events: ^events}
       } =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -155,7 +156,7 @@ defmodule Kadena.Types.LocalResponseTest do
       gas: gas,
       continuation: continuation
     } do
-      %LocalResponse{
+      %ListenResponse{
         req_key: %Base64Url{url: ^req_key},
         tx_id: nil,
         result: ^result,
@@ -165,7 +166,7 @@ defmodule Kadena.Types.LocalResponseTest do
         meta_data: nil,
         events: %OptionalPactEventsList{pact_events: nil}
       } =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: nil,
           result: result,
@@ -187,7 +188,7 @@ defmodule Kadena.Types.LocalResponseTest do
       events: events
     } do
       {:error, [req_key: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: :invalid,
           tx_id: tx_id,
           result: result,
@@ -209,7 +210,7 @@ defmodule Kadena.Types.LocalResponseTest do
       events: events
     } do
       {:error, [tx_id: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: "invalid",
           result: result,
@@ -231,7 +232,7 @@ defmodule Kadena.Types.LocalResponseTest do
       events: events
     } do
       {:error, [result: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: "invalid",
@@ -253,7 +254,7 @@ defmodule Kadena.Types.LocalResponseTest do
       events: events
     } do
       {:error, [result: :invalid, status: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: [status: :invalid_status, result: 3],
@@ -275,7 +276,7 @@ defmodule Kadena.Types.LocalResponseTest do
       events: events
     } do
       {:error, [gas: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -297,7 +298,7 @@ defmodule Kadena.Types.LocalResponseTest do
       events: events
     } do
       {:error, [logs: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -319,7 +320,7 @@ defmodule Kadena.Types.LocalResponseTest do
       events: events
     } do
       {:error, [continuation: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -341,7 +342,7 @@ defmodule Kadena.Types.LocalResponseTest do
       events: events
     } do
       {:error, [continuation: :invalid, pact_id: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -363,7 +364,7 @@ defmodule Kadena.Types.LocalResponseTest do
       events: events
     } do
       {:error, [meta_data: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -385,7 +386,7 @@ defmodule Kadena.Types.LocalResponseTest do
       events: events
     } do
       {:error, [meta_data: :invalid, block_hash: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -407,7 +408,7 @@ defmodule Kadena.Types.LocalResponseTest do
       meta_data: meta_data
     } do
       {:error, [events: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -429,7 +430,7 @@ defmodule Kadena.Types.LocalResponseTest do
       meta_data: meta_data
     } do
       {:error, [events: :invalid, pact_events: :invalid, name: :invalid]} =
-        LocalResponse.new(
+        ListenResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -439,6 +440,10 @@ defmodule Kadena.Types.LocalResponseTest do
           meta_data: meta_data,
           events: [[name: :invalid_value]]
         )
+    end
+
+    test "with an invalid list" do
+      {:error, [listen_response: :not_a_list]} = ListenResponse.new("no list")
     end
   end
 end

--- a/test/chainweb/types/local_response_test.exs
+++ b/test/chainweb/types/local_response_test.exs
@@ -1,6 +1,6 @@
-defmodule Kadena.Types.CommandResultTest do
+defmodule Kadena.Chainweb.Types.LocalResponseTest do
   @moduledoc """
-  `CommandResult` struct definition tests.
+  `LocalResponse` struct definition tests.
   """
 
   use ExUnit.Case
@@ -8,14 +8,16 @@ defmodule Kadena.Types.CommandResultTest do
   alias Kadena.Types.{
     Base64Url,
     ChainwebResponseMetaData,
-    CommandResult,
     Continuation,
+    LocalResponse,
     OptionalPactEventsList,
     PactEventsList,
     PactExec,
     PactResult,
     Yield
   }
+
+  alias Kadena.Chainweb.Types.LocalResponse
 
   describe "new/1" do
     setup do
@@ -95,7 +97,7 @@ defmodule Kadena.Types.CommandResultTest do
       events_value: events_value,
       events: events
     } do
-      %CommandResult{
+      %LocalResponse{
         req_key: %Base64Url{url: ^req_key},
         tx_id: ^tx_id,
         result: ^result,
@@ -105,7 +107,7 @@ defmodule Kadena.Types.CommandResultTest do
         meta_data: ^meta_data,
         events: %OptionalPactEventsList{pact_events: ^events}
       } =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result_value,
@@ -127,7 +129,7 @@ defmodule Kadena.Types.CommandResultTest do
       meta_data: meta_data,
       events: events
     } do
-      %CommandResult{
+      %LocalResponse{
         req_key: %Base64Url{url: ^req_key},
         tx_id: ^tx_id,
         result: ^result,
@@ -137,7 +139,7 @@ defmodule Kadena.Types.CommandResultTest do
         meta_data: ^meta_data,
         events: %OptionalPactEventsList{pact_events: ^events}
       } =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -155,7 +157,7 @@ defmodule Kadena.Types.CommandResultTest do
       gas: gas,
       continuation: continuation
     } do
-      %CommandResult{
+      %LocalResponse{
         req_key: %Base64Url{url: ^req_key},
         tx_id: nil,
         result: ^result,
@@ -165,7 +167,7 @@ defmodule Kadena.Types.CommandResultTest do
         meta_data: nil,
         events: %OptionalPactEventsList{pact_events: nil}
       } =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: nil,
           result: result,
@@ -187,7 +189,7 @@ defmodule Kadena.Types.CommandResultTest do
       events: events
     } do
       {:error, [req_key: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: :invalid,
           tx_id: tx_id,
           result: result,
@@ -209,7 +211,7 @@ defmodule Kadena.Types.CommandResultTest do
       events: events
     } do
       {:error, [tx_id: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: "invalid",
           result: result,
@@ -231,7 +233,7 @@ defmodule Kadena.Types.CommandResultTest do
       events: events
     } do
       {:error, [result: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: "invalid",
@@ -253,7 +255,7 @@ defmodule Kadena.Types.CommandResultTest do
       events: events
     } do
       {:error, [result: :invalid, status: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: [status: :invalid_status, result: 3],
@@ -275,7 +277,7 @@ defmodule Kadena.Types.CommandResultTest do
       events: events
     } do
       {:error, [gas: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -297,7 +299,7 @@ defmodule Kadena.Types.CommandResultTest do
       events: events
     } do
       {:error, [logs: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -319,7 +321,7 @@ defmodule Kadena.Types.CommandResultTest do
       events: events
     } do
       {:error, [continuation: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -341,7 +343,7 @@ defmodule Kadena.Types.CommandResultTest do
       events: events
     } do
       {:error, [continuation: :invalid, pact_id: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -363,7 +365,7 @@ defmodule Kadena.Types.CommandResultTest do
       events: events
     } do
       {:error, [meta_data: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -385,7 +387,7 @@ defmodule Kadena.Types.CommandResultTest do
       events: events
     } do
       {:error, [meta_data: :invalid, block_hash: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -407,7 +409,7 @@ defmodule Kadena.Types.CommandResultTest do
       meta_data: meta_data
     } do
       {:error, [events: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,
@@ -429,7 +431,7 @@ defmodule Kadena.Types.CommandResultTest do
       meta_data: meta_data
     } do
       {:error, [events: :invalid, pact_events: :invalid, name: :invalid]} =
-        CommandResult.new(
+        LocalResponse.new(
           req_key: req_key,
           tx_id: tx_id,
           result: result,

--- a/test/chainweb/types/poll_response_test.exs
+++ b/test/chainweb/types/poll_response_test.exs
@@ -1,4 +1,4 @@
-defmodule Kadena.Types.PollResponseTest do
+defmodule Kadena.Chainweb.Types.PollResponseTest do
   @moduledoc """
   `PollResponse` struct definition tests.
   """
@@ -8,12 +8,12 @@ defmodule Kadena.Types.PollResponseTest do
   alias Kadena.Types.{
     Base64Url,
     ChainwebResponseMetaData,
-    CommandResult,
     Continuation,
     PactResult,
-    PollResponse,
     Yield
   }
+
+  alias Kadena.Chainweb.Types.{CommandResult, PollResponse}
 
   describe "new/1" do
     setup do

--- a/test/chainweb/types/send_response_test.exs
+++ b/test/chainweb/types/send_response_test.exs
@@ -1,11 +1,12 @@
-defmodule Kadena.Types.SendResponseTest do
+defmodule Kadena.Chainweb.Types.SendResponseTest do
   @moduledoc """
   `SendResponse` struct definition tests.
   """
 
   use ExUnit.Case
 
-  alias Kadena.Types.{Base64Url, Base64UrlsList, SendResponse}
+  alias Kadena.Chainweb.Types.SendResponse
+  alias Kadena.Types.{Base64Url, Base64UrlsList}
 
   describe "new/1" do
     test "with a valid list" do

--- a/test/chainweb/types/spv_response_test.exs
+++ b/test/chainweb/types/spv_response_test.exs
@@ -1,11 +1,11 @@
-defmodule Kadena.Types.SPVResponseTest do
+defmodule Kadena.Chainweb.Types.SPVResponseTest do
   @moduledoc """
   `SPVResponse` struct definition tests.
   """
 
   use ExUnit.Case
 
-  alias Kadena.Types.SPVResponse
+  alias Kadena.Chainweb.Types.SPVResponse
 
   describe "new/1" do
     test "with a valid param" do

--- a/test/pact/command/cont_command_test.exs
+++ b/test/pact/command/cont_command_test.exs
@@ -1,0 +1,522 @@
+defmodule Kadena.Pact.ContCommandTest do
+  @moduledoc """
+  `ContCommand` struct definition tests.
+  """
+
+  use ExUnit.Case
+  alias Kadena.Cryptography.KeyPair, as: CryptographyKeyPair
+  alias Kadena.Pact.ContCommand
+
+  alias Kadena.Types.{
+    CapsList,
+    Command,
+    KeyPair,
+    MetaData,
+    PactTransactionHash,
+    Signature,
+    SignaturesList,
+    Signer,
+    SignersList
+  }
+
+  describe "create ContCommand" do
+    setup do
+      secret_key = "99f7e1e8f2f334ae8374aa28bebdb997271a0e0a5e92c80be9609684a3d6f0d4"
+      {:ok, %KeyPair{pub_key: pub_key}} = CryptographyKeyPair.from_secret_key(secret_key)
+
+      clist =
+        CapsList.new([
+          [name: "coin.GAS", args: [pub_key]]
+        ])
+
+      keypair_data = [pub_key: pub_key, secret_key: secret_key, clist: clist]
+
+      raw_meta_data = [
+        creation_time: 1_667_249_173,
+        ttl: 28_800,
+        gas_limit: 1000,
+        gas_price: 1.0e-6,
+        sender: "k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94",
+        chain_id: "0"
+      ]
+
+      %{
+        metadata: MetaData.new(raw_meta_data),
+        keypair: KeyPair.new(keypair_data),
+        signer:
+          Signer.new(
+            pub_key: pub_key,
+            scheme: :ed25519,
+            addr: pub_key,
+            clist: clist
+          ),
+        nonce: "2023-06-13 17:45:18.211131 UTC",
+        pact_tx_hash: "yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4",
+        clist: clist
+      }
+    end
+
+    test "with a valid pipe creation", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      %Command{
+        cmd:
+          "{\"meta\":{\"chainId\":\"0\",\"creationTime\":1667249173,\"gasLimit\":1000,\"gasPrice\":1.0e-6,\"sender\":\"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94\",\"ttl\":28800},\"networkId\":\"testnet04\",\"nonce\":\"2023-06-13 17:45:18.211131 UTC\",\"payload\":{\"cont\":{\"data\":{},\"pactId\":\"yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4\",\"proof\":null,\"rollback\":false,\"step\":0}},\"signers\":[{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"}]}",
+        hash: %PactTransactionHash{
+          hash: "ugR6LZOPC36gSWWtyYTrozNWqMDFsuNyZQqV-UUEGzI"
+        },
+        sigs: %SignaturesList{
+          signatures: [
+            %Signature{
+              sig:
+                "ffa2a279f4657428d579d7f60df4062bbbfc1c727470abb03078542c5b013bd97ffaaaf77873771be441b3a915ec6fbb7209b54aabe8f7dcb37681b0642d0e05"
+            }
+          ]
+        }
+      } =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+        |> ContCommand.build()
+    end
+
+    test "with a valid new args", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      cont_command =
+        ContCommand.new(
+          network_id: :testnet04,
+          data: %{},
+          nonce: nonce,
+          meta_data: metadata,
+          keypairs: [keypair],
+          signers: SignersList.new([signer]),
+          pact_tx_hash: pact_tx_hash,
+          step: 0,
+          proof: "",
+          rollback: false
+        )
+
+      %Command{
+        cmd:
+          "{\"meta\":{\"chainId\":\"0\",\"creationTime\":1667249173,\"gasLimit\":1000,\"gasPrice\":1.0e-6,\"sender\":\"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94\",\"ttl\":28800},\"networkId\":\"testnet04\",\"nonce\":\"2023-06-13 17:45:18.211131 UTC\",\"payload\":{\"cont\":{\"data\":{},\"pactId\":\"yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4\",\"proof\":\"\",\"rollback\":false,\"step\":0}},\"signers\":[{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"}]}",
+        hash: %PactTransactionHash{
+          hash: "1S6E7eTqWPLQ8YVL9v31f9NW56aeQBQAH-EJZK_ognw"
+        },
+        sigs: %SignaturesList{
+          signatures: [
+            %Signature{
+              sig:
+                "1c1632e5f98cd7c948c86e90ca7bb984695e70d6dd81fe44d669d71878be3cc11db078cf72ec4cdb67e0fb7ef4730539554c91a559e666c821a6add33c785e01"
+            }
+          ]
+        }
+      } = ContCommand.build(cont_command)
+    end
+
+    test "with a keypair list", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      %Command{
+        cmd:
+          "{\"meta\":{\"chainId\":\"0\",\"creationTime\":1667249173,\"gasLimit\":1000,\"gasPrice\":1.0e-6,\"sender\":\"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94\",\"ttl\":28800},\"networkId\":\"testnet04\",\"nonce\":\"2023-06-13 17:45:18.211131 UTC\",\"payload\":{\"cont\":{\"data\":{},\"pactId\":\"yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4\",\"proof\":null,\"rollback\":false,\"step\":0}},\"signers\":[{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"}]}",
+        hash: %PactTransactionHash{
+          hash: "ugR6LZOPC36gSWWtyYTrozNWqMDFsuNyZQqV-UUEGzI"
+        },
+        sigs: %SignaturesList{
+          signatures: [
+            %Signature{
+              sig:
+                "ffa2a279f4657428d579d7f60df4062bbbfc1c727470abb03078542c5b013bd97ffaaaf77873771be441b3a915ec6fbb7209b54aabe8f7dcb37681b0642d0e05"
+            },
+            %Signature{
+              sig:
+                "ffa2a279f4657428d579d7f60df4062bbbfc1c727470abb03078542c5b013bd97ffaaaf77873771be441b3a915ec6fbb7209b54aabe8f7dcb37681b0642d0e05"
+            }
+          ]
+        }
+      } =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypairs([keypair, keypair])
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+        |> ContCommand.build()
+    end
+
+    test "with a signer in existing signer_list", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      %Command{
+        cmd:
+          "{\"meta\":{\"chainId\":\"0\",\"creationTime\":1667249173,\"gasLimit\":1000,\"gasPrice\":1.0e-6,\"sender\":\"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94\",\"ttl\":28800},\"networkId\":\"testnet04\",\"nonce\":\"2023-06-13 17:45:18.211131 UTC\",\"payload\":{\"cont\":{\"data\":{},\"pactId\":\"yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4\",\"proof\":null,\"rollback\":false,\"step\":0}},\"signers\":[{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"},{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"}]}",
+        hash: %PactTransactionHash{
+          hash: "NH1oRytubJHKE7I4W6UWsnfvF2NlehctV8H71o6_vfY"
+        },
+        sigs: %SignaturesList{
+          signatures: [
+            %Signature{
+              sig:
+                "fa9924f206f6e95d3f3594ce954577d275e56d1bad23e348942ee261a93653c1186b4d02c88858d4103237041850548dd1469b002acc6bbd8cf6502fbdae3507"
+            }
+          ]
+        }
+      } =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+        |> ContCommand.build()
+    end
+
+    test "with a SignersList", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      signers_list = SignersList.new([signer, signer])
+
+      %Command{
+        cmd:
+          "{\"meta\":{\"chainId\":\"0\",\"creationTime\":1667249173,\"gasLimit\":1000,\"gasPrice\":1.0e-6,\"sender\":\"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94\",\"ttl\":28800},\"networkId\":\"testnet04\",\"nonce\":\"2023-06-13 17:45:18.211131 UTC\",\"payload\":{\"cont\":{\"data\":{},\"pactId\":\"yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4\",\"proof\":null,\"rollback\":false,\"step\":0}},\"signers\":[{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"},{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"}]}",
+        hash: %PactTransactionHash{
+          hash: "NH1oRytubJHKE7I4W6UWsnfvF2NlehctV8H71o6_vfY"
+        },
+        sigs: %SignaturesList{
+          signatures: [
+            %Signature{
+              sig:
+                "fa9924f206f6e95d3f3594ce954577d275e56d1bad23e348942ee261a93653c1186b4d02c88858d4103237041850548dd1469b002acc6bbd8cf6502fbdae3507"
+            }
+          ]
+        }
+      } =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signers(signers_list)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+        |> ContCommand.build()
+    end
+
+    test "with an invalid data in build function", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      {:error, [exec_command_request: :invalid_payload]} =
+        ContCommand.new()
+        |> ContCommand.set_data(8_947_289)
+        |> ContCommand.set_network(:invalid)
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_keypairs([keypair])
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.add_signers(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_proof(123)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+        |> ContCommand.build()
+    end
+
+    test "with an invalid newtwork_id", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      {:error, [network_id: :invalid, id: :invalid]} =
+        ContCommand.new()
+        |> ContCommand.set_network("invalid_value")
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+    end
+
+    test "with an invalid pact_tx_hash", %{
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      {:error, [pact_tx_hash: :not_a_string]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(12)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+    end
+
+    test "with an invalid data", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      {:error, [data: :invalid]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data("invalid_value")
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+    end
+
+    test "with an invalid step", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      {:error, [step: :not_an_integer]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step("invalid_value")
+        |> ContCommand.set_rollback(false)
+    end
+
+    test "with an invalid rollback", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      {:error, [rollback: :not_a_boolean]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback("invalid")
+    end
+
+    test "with an invalid proof", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      {:error, [proof: :not_a_string]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_proof(999)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+    end
+
+    test "with an invalid nonce", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      signer: signer
+    } do
+      {:error, [nonce: :not_a_string]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(:not_a_string)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_proof(nil)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+    end
+
+    test "with an invalid metadata", %{
+      pact_tx_hash: pact_tx_hash,
+      keypair: keypair,
+      signer: signer,
+      nonce: nonce
+    } do
+      {:error, [metadata: :invalid]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata("invalid_value")
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+    end
+
+    test "with an invalid keypair", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      signer: signer,
+      nonce: nonce
+    } do
+      {:error, [keypair: :invalid]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair("invalid_value")
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+    end
+
+    test "with an invalid keypairs", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      signer: signer,
+      nonce: nonce
+    } do
+      {:error, [keypairs: :not_a_list]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypairs("invalid_value")
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+    end
+
+    test "with an invalid keypairs list", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      signer: signer,
+      nonce: nonce
+    } do
+      {:error, [keypairs: :not_a_list]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypairs("invalid_value")
+        |> ContCommand.add_signer(signer)
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+    end
+
+    test "with an invalid signers", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      nonce: nonce
+    } do
+      {:error, [signers: :invalid]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signers("invalid_value")
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+    end
+
+    test "with an invalid signer", %{
+      pact_tx_hash: pact_tx_hash,
+      metadata: metadata,
+      keypair: keypair,
+      nonce: nonce
+    } do
+      {:error, [signer: :invalid]} =
+        ContCommand.new()
+        |> ContCommand.set_network(:testnet04)
+        |> ContCommand.set_data(%{})
+        |> ContCommand.set_nonce(nonce)
+        |> ContCommand.set_metadata(metadata)
+        |> ContCommand.add_keypair(keypair)
+        |> ContCommand.add_signer("invalid_value")
+        |> ContCommand.set_pact_tx_hash(pact_tx_hash)
+        |> ContCommand.set_step(0)
+        |> ContCommand.set_rollback(false)
+    end
+  end
+end

--- a/test/pact/command/exec_command_test.exs
+++ b/test/pact/command/exec_command_test.exs
@@ -42,9 +42,7 @@ defmodule Kadena.Pact.ExecCommandTest do
 
       %{
         meta_data: MetaData.new(raw_meta_data),
-        raw_meta_data: raw_meta_data,
         keypair: KeyPair.new(keypair_data),
-        keypair_data: keypair_data,
         signer:
           Signer.new(
             pub_key: pub_key,
@@ -159,72 +157,6 @@ defmodule Kadena.Pact.ExecCommandTest do
         |> ExecCommand.build()
     end
 
-    test "with a valid keyword list in meta_data", %{
-      raw_meta_data: raw_meta_data,
-      keypair: keypair,
-      signer: signer,
-      nonce: nonce,
-      code: code
-    } do
-      %Command{
-        cmd:
-          "{\"meta\":{\"chainId\":\"0\",\"creationTime\":1667249173,\"gasLimit\":1000,\"gasPrice\":1.0e-6,\"sender\":\"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94\",\"ttl\":28800},\"networkId\":\"testnet04\",\"nonce\":\"2023-06-13 17:45:18.211131 UTC\",\"payload\":{\"exec\":{\"code\":\"(+ 5 6)\",\"data\":{}}},\"signers\":[{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"}]}",
-        hash: %PactTransactionHash{
-          hash: "3BeOVboVQ9TwWAiQS65YHkgxOOiBQT5uMcQDm3vmNVA"
-        },
-        sigs: %SignaturesList{
-          signatures: [
-            %Signature{
-              sig:
-                "e4ea07728a52b564156ea44aa2817931b56829eaa361f1b5c4f2a419acaa5c9c77e4e29ac55f5d250d27d066dc8b4f1076fdc5d402fa4cbffe2f63dc36e1e705"
-            }
-          ]
-        }
-      } =
-        ExecCommand.new()
-        |> ExecCommand.set_network(:testnet04)
-        |> ExecCommand.set_data(%{})
-        |> ExecCommand.set_code(code)
-        |> ExecCommand.set_nonce(nonce)
-        |> ExecCommand.set_metadata(raw_meta_data)
-        |> ExecCommand.add_keypair(keypair)
-        |> ExecCommand.add_signer(signer)
-        |> ExecCommand.build()
-    end
-
-    test "with a valid keyword list in keypair", %{
-      meta_data: meta_data,
-      keypair_data: keypair_data,
-      signer: signer,
-      nonce: nonce,
-      code: code
-    } do
-      %Command{
-        cmd:
-          "{\"meta\":{\"chainId\":\"0\",\"creationTime\":1667249173,\"gasLimit\":1000,\"gasPrice\":1.0e-6,\"sender\":\"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94\",\"ttl\":28800},\"networkId\":\"testnet04\",\"nonce\":\"2023-06-13 17:45:18.211131 UTC\",\"payload\":{\"exec\":{\"code\":\"(+ 5 6)\",\"data\":{}}},\"signers\":[{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"}]}",
-        hash: %PactTransactionHash{
-          hash: "3BeOVboVQ9TwWAiQS65YHkgxOOiBQT5uMcQDm3vmNVA"
-        },
-        sigs: %SignaturesList{
-          signatures: [
-            %Signature{
-              sig:
-                "e4ea07728a52b564156ea44aa2817931b56829eaa361f1b5c4f2a419acaa5c9c77e4e29ac55f5d250d27d066dc8b4f1076fdc5d402fa4cbffe2f63dc36e1e705"
-            }
-          ]
-        }
-      } =
-        ExecCommand.new()
-        |> ExecCommand.set_network(:testnet04)
-        |> ExecCommand.set_data(%{})
-        |> ExecCommand.set_code(code)
-        |> ExecCommand.set_nonce(nonce)
-        |> ExecCommand.set_metadata(meta_data)
-        |> ExecCommand.add_keypair(keypair_data)
-        |> ExecCommand.add_signer(signer)
-        |> ExecCommand.build()
-    end
-
     test "with a keypair list", %{
       meta_data: meta_data,
       keypair: keypair,
@@ -297,41 +229,6 @@ defmodule Kadena.Pact.ExecCommandTest do
         |> ExecCommand.build()
     end
 
-    test "with a signers list", %{
-      meta_data: meta_data,
-      keypair: keypair,
-      signer: signer,
-      nonce: nonce,
-      code: code
-    } do
-      signers_list = [signer, signer]
-
-      %Command{
-        cmd:
-          "{\"meta\":{\"chainId\":\"0\",\"creationTime\":1667249173,\"gasLimit\":1000,\"gasPrice\":1.0e-6,\"sender\":\"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94\",\"ttl\":28800},\"networkId\":\"testnet04\",\"nonce\":\"2023-06-13 17:45:18.211131 UTC\",\"payload\":{\"exec\":{\"code\":\"(+ 5 6)\",\"data\":{}}},\"signers\":[{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"},{\"addr\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"clist\":[{\"args\":[\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\"],\"name\":\"coin.GAS\"}],\"pubKey\":\"6ffea3fabe4e7fe6a89f88fc6d662c764ed1359fbc03a28afdac3935415347d7\",\"scheme\":\"ED25519\"}]}",
-        hash: %PactTransactionHash{
-          hash: "niwT670sdzjiBWlORejSHsaoVQHPfUiNkxtcVQfDysM"
-        },
-        sigs: %SignaturesList{
-          signatures: [
-            %Signature{
-              sig:
-                "4a35b98eb50179c77784532ea7224d119f06c8a9853c421bd0cd3e667b54213840d01ee926ab19a02d0777f68297b88bbc5799bcd281ed0e9c2c7993dab7740b"
-            }
-          ]
-        }
-      } =
-        ExecCommand.new()
-        |> ExecCommand.set_network(:testnet04)
-        |> ExecCommand.set_data(%{})
-        |> ExecCommand.set_code(code)
-        |> ExecCommand.set_nonce(nonce)
-        |> ExecCommand.set_metadata(meta_data)
-        |> ExecCommand.add_keypair(keypair)
-        |> ExecCommand.add_signers(signers_list)
-        |> ExecCommand.build()
-    end
-
     test "with an invalid data in build function", %{
       meta_data: meta_data,
       keypair: keypair,
@@ -347,7 +244,8 @@ defmodule Kadena.Pact.ExecCommandTest do
         |> ExecCommand.set_nonce(nonce)
         |> ExecCommand.set_metadata(meta_data)
         |> ExecCommand.add_keypair(keypair)
-        |> ExecCommand.add_signers([signer])
+        |> ExecCommand.add_signer(signer)
+        |> ExecCommand.add_signers(signer)
         |> ExecCommand.build()
     end
 
@@ -366,7 +264,7 @@ defmodule Kadena.Pact.ExecCommandTest do
         |> ExecCommand.set_nonce(nonce)
         |> ExecCommand.set_metadata(meta_data)
         |> ExecCommand.add_keypair(keypair)
-        |> ExecCommand.add_signers([signer])
+        |> ExecCommand.add_signer(signer)
     end
 
     test "with an invalid data", %{
@@ -384,7 +282,7 @@ defmodule Kadena.Pact.ExecCommandTest do
         |> ExecCommand.set_nonce(nonce)
         |> ExecCommand.set_metadata(meta_data)
         |> ExecCommand.add_keypair(keypair)
-        |> ExecCommand.add_signers([signer])
+        |> ExecCommand.add_signer(signer)
     end
 
     test "with an invalid code", %{
@@ -402,7 +300,7 @@ defmodule Kadena.Pact.ExecCommandTest do
         |> ExecCommand.set_nonce(nonce)
         |> ExecCommand.set_metadata(meta_data)
         |> ExecCommand.add_keypair(keypair)
-        |> ExecCommand.add_signers([signer])
+        |> ExecCommand.add_signer(signer)
     end
 
     test "with an invalid nonce", %{
@@ -419,7 +317,7 @@ defmodule Kadena.Pact.ExecCommandTest do
         |> ExecCommand.set_nonce(123)
         |> ExecCommand.set_metadata(meta_data)
         |> ExecCommand.add_keypair(keypair)
-        |> ExecCommand.add_signers([signer])
+        |> ExecCommand.add_signer(signer)
     end
 
     test "with an invalid meta_data", %{
@@ -428,7 +326,7 @@ defmodule Kadena.Pact.ExecCommandTest do
       nonce: nonce,
       code: code
     } do
-      {:error, [meta_data: :invalid, args: :not_a_list]} =
+      {:error, [metadata: :invalid]} =
         ExecCommand.new()
         |> ExecCommand.set_network(:testnet04)
         |> ExecCommand.set_data(%{})
@@ -436,7 +334,7 @@ defmodule Kadena.Pact.ExecCommandTest do
         |> ExecCommand.set_nonce(nonce)
         |> ExecCommand.set_metadata("invalid value")
         |> ExecCommand.add_keypairs([keypair])
-        |> ExecCommand.add_signers([signer])
+        |> ExecCommand.add_signer(signer)
     end
 
     test "with an invalid keypair", %{
@@ -445,7 +343,7 @@ defmodule Kadena.Pact.ExecCommandTest do
       nonce: nonce,
       code: code
     } do
-      {:error, [keypair: :invalid, args: :not_a_list]} =
+      {:error, [keypair: :invalid]} =
         ExecCommand.new()
         |> ExecCommand.set_network(:testnet04)
         |> ExecCommand.set_data(%{})
@@ -479,7 +377,7 @@ defmodule Kadena.Pact.ExecCommandTest do
       nonce: nonce,
       code: code
     } do
-      {:error, [keypair: :invalid, args: :not_a_list]} =
+      {:error, [keypair: :invalid]} =
         ExecCommand.new()
         |> ExecCommand.set_network(:testnet04)
         |> ExecCommand.set_data(%{})
@@ -496,7 +394,7 @@ defmodule Kadena.Pact.ExecCommandTest do
       nonce: nonce,
       code: code
     } do
-      {:error, [signers: :invalid, signers: :invalid_type]} =
+      {:error, [signers: :invalid]} =
         ExecCommand.new()
         |> ExecCommand.set_network(:testnet04)
         |> ExecCommand.set_data(%{})

--- a/test/types/command_payload_test.exs
+++ b/test/types/command_payload_test.exs
@@ -695,7 +695,7 @@ defmodule Kadena.Types.CommandPayloadTest do
           nonce: "2023-06-13 17:45:18.211131 UTC"
         )
 
-      ~s({"meta":{"chainId":"0","creationTime":1667249173,"gasLimit":1000,"gasPrice":1.0e-6,"sender":"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94","ttl":28800},"networkId":"testnet04","nonce":"2023-06-13 17:45:18.211131 UTC","payload":{\"cont\":{\"data\":{},\"pactId\":\"yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4\",\"proof\":"valid_proof",\"roollback\":true,\"step\":2}},"signers":[{"addr":"#{"85bef77ea3570387cac57da34938f246c7460dc533a67823f065823e327b2afd"}","clist":[{"args":[["#{"9007199254740992.553"}"]],"name":"coin.GAS"}],"pubKey":"#{"85bef77ea3570387cac57da34938f246c7460dc533a67823f065823e327b2afd"}","scheme":"ED25519"}]}) =
+      ~s({"meta":{"chainId":"0","creationTime":1667249173,"gasLimit":1000,"gasPrice":1.0e-6,"sender":"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94","ttl":28800},"networkId":"testnet04","nonce":"2023-06-13 17:45:18.211131 UTC","payload":{\"cont\":{\"data\":{},\"pactId\":\"yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4\",\"proof\":"valid_proof",\"rollback\":true,\"step\":2}},"signers":[{"addr":"#{"85bef77ea3570387cac57da34938f246c7460dc533a67823f065823e327b2afd"}","clist":[{"args":[["#{"9007199254740992.553"}"]],"name":"coin.GAS"}],"pubKey":"#{"85bef77ea3570387cac57da34938f246c7460dc533a67823f065823e327b2afd"}","scheme":"ED25519"}]}) =
         JSONPayload.parse(command_payload)
     end
 
@@ -743,7 +743,7 @@ defmodule Kadena.Types.CommandPayloadTest do
           nonce: "2023-06-13 17:45:18.211131 UTC"
         )
 
-      ~s({"meta":{"chainId":"0","creationTime":1667249173,"gasLimit":1000,"gasPrice":1.0e-6,"sender":"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94","ttl":28800},"networkId":"testnet04","nonce":"2023-06-13 17:45:18.211131 UTC","payload":{\"cont\":{\"data\":{},\"pactId\":\"yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4\",\"proof\":null,\"roollback\":true,\"step\":2}},"signers":[{"addr":"#{"85bef77ea3570387cac57da34938f246c7460dc533a67823f065823e327b2afd"}","clist":[{"args":[["#{"9007199254740992.553"}"]],"name":"coin.GAS"}],"pubKey":"#{"85bef77ea3570387cac57da34938f246c7460dc533a67823f065823e327b2afd"}","scheme":"ED25519"}]}) =
+      ~s({"meta":{"chainId":"0","creationTime":1667249173,"gasLimit":1000,"gasPrice":1.0e-6,"sender":"k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94","ttl":28800},"networkId":"testnet04","nonce":"2023-06-13 17:45:18.211131 UTC","payload":{\"cont\":{\"data\":{},\"pactId\":\"yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4\",\"proof\":null,\"rollback\":true,\"step\":2}},"signers":[{"addr":"#{"85bef77ea3570387cac57da34938f246c7460dc533a67823f065823e327b2afd"}","clist":[{"args":[["#{"9007199254740992.553"}"]],"name":"coin.GAS"}],"pubKey":"#{"85bef77ea3570387cac57da34938f246c7460dc533a67823f065823e327b2afd"}","scheme":"ED25519"}]}) =
         JSONPayload.parse(command_payload)
     end
   end

--- a/test/types/keypair_test.exs
+++ b/test/types/keypair_test.exs
@@ -61,5 +61,9 @@ defmodule Kadena.Types.KeypairTest do
       keypair = KeyPair.new(pub_key: pub_key, secret_key: secret_key)
       {:error, [clist: :invalid]} = KeyPair.add_caps(keypair, "invalid")
     end
+
+    test "with an invalid KeywordList" do
+      {:error, [args: :not_a_list]} = KeyPair.new("invalid_args")
+    end
   end
 end

--- a/test/types/meta_data_test.exs
+++ b/test/types/meta_data_test.exs
@@ -102,5 +102,9 @@ defmodule Kadena.Types.MetaDataTest do
           chain_id: 0
         )
     end
+
+    test "with an invalid KeywordList" do
+      {:error, [args: :not_a_list]} = MetaData.new("invalid_args")
+    end
   end
 end


### PR DESCRIPTION
## 0.9.0 (08.12.2022)
- Added [Continuation Command](https://github.com/kommitters/kadena.ex/issues/133)
- Relocated Chainweb types
- Improved the README documentation