### PR TITLE
Implement Pact resources derived from CommandResult

### DIFF
--- a/lib/chainweb/pact/resources/command_result.ex
+++ b/lib/chainweb/pact/resources/command_result.ex
@@ -1,0 +1,56 @@
+defmodule Kadena.Chainweb.Pact.Resources.CommandResult do
+  @moduledoc """
+  `CommandResult` struct definition.
+  """
+
+  alias Kadena.Chainweb.Mapping
+
+  alias Kadena.Chainweb.Pact.Resources.{
+    PactEventsList,
+    PactExec,
+    PactResult,
+    ResponseMetaData
+  }
+
+  alias Kadena.Types.Base64Url
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type str :: String.t()
+  @type req_key :: Base64Url.t()
+  @type tx_id :: number() | nil
+  @type result :: PactResult.t()
+  @type gas :: number()
+  @type logs :: String.t() | nil
+  @type continuation :: PactExec.t() | nil
+  @type meta_data :: ResponseMetaData.t() | nil
+  @type events :: PactEventsList.t() | nil
+
+  @type t :: %__MODULE__{
+          req_key: req_key(),
+          tx_id: tx_id(),
+          result: result(),
+          gas: gas(),
+          logs: logs(),
+          continuation: continuation(),
+          meta_data: meta_data(),
+          events: events()
+        }
+
+  defstruct [:req_key, :tx_id, :result, :gas, :logs, :continuation, :meta_data, :events]
+
+  @mapping [
+    req_key: {:struct, Base64Url},
+    result: {:struct, PactResult},
+    continuation: {:struct, PactExec},
+    meta_data: {:struct, ResponseMetaData},
+    events: {:struct, PactEventsList}
+  ]
+
+  @impl true
+  def new(attrs) do
+    %__MODULE__{}
+    |> Mapping.build(attrs)
+    |> Mapping.parse(@mapping)
+  end
+end

--- a/lib/chainweb/pact/resources/continuation.ex
+++ b/lib/chainweb/pact/resources/continuation.ex
@@ -1,0 +1,29 @@
+defmodule Kadena.Chainweb.Pact.Resources.Continuation do
+  @moduledoc """
+  `Continuation` struct definition.
+  """
+
+  alias Kadena.Chainweb.Mapping
+  alias Kadena.Types.PactValue
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type continuation_def :: String.t()
+  @type args :: PactValue.t()
+
+  @type t :: %__MODULE__{
+          def: continuation_def(),
+          args: args()
+        }
+
+  defstruct [:def, :args]
+
+  @mapping [args: {:struct, PactValue}]
+
+  @impl true
+  def new(attrs) do
+    %__MODULE__{}
+    |> Mapping.build(attrs)
+    |> Mapping.parse(@mapping)
+  end
+end

--- a/lib/chainweb/pact/resources/listen_response.ex
+++ b/lib/chainweb/pact/resources/listen_response.ex
@@ -1,0 +1,57 @@
+defmodule Kadena.Chainweb.Pact.Resources.ListenResponse do
+  @moduledoc """
+  `ListenResponse` struct definition.
+  """
+
+  alias Kadena.Types.{
+    Base64Url,
+    PactExec
+  }
+
+  alias Kadena.Chainweb.Pact.Resources.{
+    CommandResult,
+    PactEventsList,
+    PactResult,
+    ResponseMetaData
+  }
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type req_key :: Base64Url.t()
+  @type tx_id :: number() | nil
+  @type result :: PactResult.t()
+  @type gas :: number()
+  @type logs :: String.t() | nil
+  @type continuation :: PactExec.t()
+  @type meta_data :: ResponseMetaData.t() | nil
+  @type events :: PactEventsList.t() | nil
+
+  @type command_result :: CommandResult.t()
+  @type validation :: t() | {:error, Keyword.t()}
+
+  @type t :: %__MODULE__{
+          req_key: req_key(),
+          tx_id: tx_id(),
+          result: result(),
+          gas: gas(),
+          logs: logs(),
+          continuation: continuation(),
+          meta_data: meta_data(),
+          events: events()
+        }
+
+  defstruct [:req_key, :tx_id, :result, :gas, :logs, :continuation, :meta_data, :events]
+
+  @impl true
+  def new(attrs) do
+    attrs
+    |> CommandResult.new()
+    |> build_listen_response()
+  end
+
+  @spec build_listen_response(command_result :: command_result()) :: validation()
+  defp build_listen_response(%CommandResult{} = command_result) do
+    attrs = Map.from_struct(command_result)
+    struct(%__MODULE__{}, attrs)
+  end
+end

--- a/lib/chainweb/pact/resources/local_response.ex
+++ b/lib/chainweb/pact/resources/local_response.ex
@@ -1,0 +1,53 @@
+defmodule Kadena.Chainweb.Pact.Resources.LocalResponse do
+  @moduledoc """
+  `LocalResponse` struct definition.
+  """
+
+  alias Kadena.Types.Base64Url
+
+  alias Kadena.Chainweb.Pact.Resources.{
+    CommandResult,
+    PactEventsList,
+    PactExec,
+    PactResult,
+    ResponseMetaData
+  }
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type req_key :: Base64Url.t()
+  @type tx_id :: number() | nil
+  @type result :: PactResult.t()
+  @type gas :: number()
+  @type logs :: String.t() | nil
+  @type continuation :: PactExec.t()
+  @type meta_data :: ResponseMetaData.t() | nil
+  @type events :: PactEventsList.t() | nil
+  @type command_result :: CommandResult.t()
+
+  @type t :: %__MODULE__{
+          req_key: req_key(),
+          tx_id: tx_id(),
+          result: result(),
+          gas: gas(),
+          logs: logs(),
+          continuation: continuation(),
+          meta_data: meta_data(),
+          events: events()
+        }
+
+  defstruct [:req_key, :tx_id, :result, :gas, :logs, :continuation, :meta_data, :events]
+
+  @impl true
+  def new(attrs) do
+    attrs
+    |> CommandResult.new()
+    |> build_local_request_body()
+  end
+
+  @spec build_local_request_body(command_result :: command_result()) :: t()
+  defp build_local_request_body(%CommandResult{} = command_result) do
+    attrs = Map.from_struct(command_result)
+    struct(%__MODULE__{}, attrs)
+  end
+end

--- a/lib/chainweb/pact/resources/meta_data_result.ex
+++ b/lib/chainweb/pact/resources/meta_data_result.ex
@@ -1,0 +1,37 @@
+defmodule Kadena.Chainweb.Pact.Resources.MetaDataResult do
+  @moduledoc """
+  `MetaDataResult` struct definition.
+  """
+
+  alias Kadena.Chainweb.Mapping
+  alias Kadena.Types.ChainID
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type creation_time :: number()
+  @type ttl :: number()
+  @type gas_limit :: number()
+  @type gas_price :: number()
+  @type sender :: String.t()
+  @type chain_id :: ChainID.t()
+
+  @type t :: %__MODULE__{
+          creation_time: creation_time(),
+          ttl: ttl(),
+          gas_limit: gas_limit(),
+          gas_price: gas_price(),
+          sender: sender(),
+          chain_id: chain_id()
+        }
+
+  defstruct [:creation_time, :ttl, :gas_limit, :gas_price, :sender, :chain_id]
+
+  @mapping [chain_id: {:struct, ChainID}]
+
+  @impl true
+  def new(attrs) do
+    %__MODULE__{}
+    |> Mapping.build(attrs)
+    |> Mapping.parse(@mapping)
+  end
+end

--- a/lib/chainweb/pact/resources/pact_event.ex
+++ b/lib/chainweb/pact/resources/pact_event.ex
@@ -1,0 +1,37 @@
+defmodule Kadena.Chainweb.Pact.Resources.PactEvent do
+  @moduledoc """
+  `PactEventModule` struct definition.
+  """
+
+  alias Kadena.Chainweb.Mapping
+  alias Kadena.Chainweb.Pact.Resources.PactEventModule
+  alias Kadena.Types.PactValuesList
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type name :: String.t()
+  @type pact_event_module :: PactEventModule.t()
+  @type params :: PactValuesList.t()
+  @type module_hash :: String.t()
+
+  @type t :: %__MODULE__{
+          name: name(),
+          module: pact_event_module(),
+          params: params(),
+          module_hash: module_hash()
+        }
+
+  defstruct [:name, :module, :params, :module_hash]
+
+  @mapping [
+    module: {:struct, PactEventModule},
+    params: {:struct, PactValuesList}
+  ]
+
+  @impl true
+  def new(attrs) do
+    %__MODULE__{}
+    |> Mapping.build(attrs)
+    |> Mapping.parse(@mapping)
+  end
+end

--- a/lib/chainweb/pact/resources/pact_event_module.ex
+++ b/lib/chainweb/pact/resources/pact_event_module.ex
@@ -1,0 +1,19 @@
+defmodule Kadena.Chainweb.Pact.Resources.PactEventModule do
+  @moduledoc """
+  `PactEventModule` struct definition.
+  """
+
+  alias Kadena.Chainweb.Mapping
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type name :: String.t()
+  @type namespace :: String.t() | nil
+
+  @type t :: %__MODULE__{name: name(), namespace: namespace()}
+
+  defstruct [:name, :namespace]
+
+  @impl true
+  def new(attrs), do: Mapping.build(%__MODULE__{}, attrs)
+end

--- a/lib/chainweb/pact/resources/pact_events_list.ex
+++ b/lib/chainweb/pact/resources/pact_events_list.ex
@@ -1,0 +1,27 @@
+defmodule Kadena.Chainweb.Pact.Resources.PactEventsList do
+  @moduledoc """
+  `PactEventsList` struct definition.
+  """
+  alias Kadena.Chainweb.Mapping
+  alias Kadena.Chainweb.Pact.Resources.PactEvent
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type pact_event :: PactEvent.t()
+  @type pact_events :: list(pact_event())
+
+  @type t :: %__MODULE__{pact_events: pact_events()}
+
+  defstruct pact_events: []
+
+  @mapping [pact_events: {:list, :struct, PactEvent}]
+
+  @impl true
+  def new(pact_events) do
+    attrs = %{"pact_events" => pact_events}
+
+    %__MODULE__{}
+    |> Mapping.build(attrs)
+    |> Mapping.parse(@mapping)
+  end
+end

--- a/lib/chainweb/pact/resources/pact_exec.ex
+++ b/lib/chainweb/pact/resources/pact_exec.ex
@@ -1,0 +1,50 @@
+defmodule Kadena.Chainweb.Pact.Resources.PactExec do
+  @moduledoc """
+  `PactExec` struct definition.
+  """
+
+  alias Kadena.Chainweb.Mapping
+
+  alias Kadena.Chainweb.Pact.Resources.{
+    Continuation,
+    Yield
+  }
+
+  alias Kadena.Types.{PactTransactionHash, Step}
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type pact_id :: PactTransactionHash.t()
+  @type step :: Step.t()
+  @type step_count :: integer()
+  @type executed :: boolean() | nil
+  @type step_has_rollback :: boolean()
+  @type continuation :: Continuation.t()
+  @type yield :: Yield.t() | nil
+
+  @type t :: %__MODULE__{
+          pact_id: pact_id(),
+          step: step(),
+          step_count: step_count(),
+          executed: executed(),
+          step_has_rollback: step_has_rollback(),
+          continuation: continuation(),
+          yield: yield()
+        }
+
+  defstruct [:pact_id, :step, :step_count, :executed, :step_has_rollback, :continuation, :yield]
+
+  @mapping [
+    pact_id: {:struct, PactTransactionHash},
+    step: {:struct, Step},
+    continuation: {:struct, Continuation},
+    yield: {:struct, Yield}
+  ]
+
+  @impl true
+  def new(attrs) do
+    %__MODULE__{}
+    |> Mapping.build(attrs)
+    |> Mapping.parse(@mapping)
+  end
+end

--- a/lib/chainweb/pact/resources/pact_result.ex
+++ b/lib/chainweb/pact/resources/pact_result.ex
@@ -1,0 +1,35 @@
+defmodule Kadena.Chainweb.Pact.Resources.PactResult do
+  @moduledoc """
+  `PactResult` struct definition.
+  """
+
+  alias Kadena.Types.PactValue
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type status :: :success | :failure
+  @type error :: map()
+  @type data :: PactValue.t() | error()
+
+  @type t :: %__MODULE__{
+          status: status(),
+          data: data()
+        }
+
+  defstruct [:status, :data]
+
+  @impl true
+  def new(%{"status" => "success", "data" => data}) do
+    %__MODULE__{
+      status: :success,
+      data: PactValue.new(data)
+    }
+  end
+
+  def new(%{"status" => "failure", "data" => data}) do
+    %__MODULE__{
+      status: :failure,
+      data: data
+    }
+  end
+end

--- a/lib/chainweb/pact/resources/poll_response.ex
+++ b/lib/chainweb/pact/resources/poll_response.ex
@@ -1,0 +1,28 @@
+defmodule Kadena.Chainweb.Pact.Resources.PollResponse do
+  @moduledoc """
+  `PollResponse` struct definition.
+  """
+
+  alias Kadena.Chainweb.Mapping
+  alias Kadena.Chainweb.Pact.Resources.CommandResult
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type results :: list(CommandResult.t())
+
+  @type t :: %__MODULE__{results: results()}
+
+  defstruct [:results]
+
+  @mapping [results: {:list, :struct, CommandResult}]
+
+  @impl true
+  def new(attrs) do
+    values = Map.values(attrs)
+    attrs = %{"results" => values}
+
+    %__MODULE__{}
+    |> Mapping.build(attrs)
+    |> Mapping.parse(@mapping)
+  end
+end

--- a/lib/chainweb/pact/resources/provenance.ex
+++ b/lib/chainweb/pact/resources/provenance.ex
@@ -1,0 +1,29 @@
+defmodule Kadena.Chainweb.Pact.Resources.Provenance do
+  @moduledoc """
+  `Provenance` struct definition.
+  """
+
+  alias Kadena.Chainweb.Mapping
+  alias Kadena.Types.ChainID
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type target_chain_id :: ChainID.t()
+  @type module_hash :: String.t()
+
+  @type t :: %__MODULE__{
+          target_chain_id: target_chain_id(),
+          module_hash: module_hash()
+        }
+
+  defstruct [:target_chain_id, :module_hash]
+
+  @mapping [target_chain_id: {:struct, ChainID}]
+
+  @impl true
+  def new(attrs) do
+    %__MODULE__{}
+    |> Mapping.build(attrs)
+    |> Mapping.parse(@mapping)
+  end
+end

--- a/lib/chainweb/pact/resources/response_meta_data.ex
+++ b/lib/chainweb/pact/resources/response_meta_data.ex
@@ -1,0 +1,37 @@
+defmodule Kadena.Chainweb.Pact.Resources.ResponseMetaData do
+  @moduledoc """
+  `ResponseMetaData` struct definition.
+  """
+
+  alias Kadena.Chainweb.Mapping
+  alias Kadena.Chainweb.Pact.Resources.MetaDataResult
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type hash :: String.t()
+  @type block_hash :: hash()
+  @type block_number :: number()
+  @type block_time :: block_number()
+  @type block_height :: block_number()
+  @type prev_block_hash :: hash()
+  @type public_meta :: MetaDataResult.t() | nil
+
+  @type t :: %__MODULE__{
+          block_hash: block_hash(),
+          block_time: block_time(),
+          block_height: block_height(),
+          prev_block_hash: prev_block_hash(),
+          public_meta: public_meta()
+        }
+
+  defstruct [:block_hash, :block_time, :block_height, :prev_block_hash, :public_meta]
+
+  @mapping [public_meta: {:struct, MetaDataResult}]
+
+  @impl true
+  def new(attrs) do
+    %__MODULE__{}
+    |> Mapping.build(attrs)
+    |> Mapping.parse(@mapping)
+  end
+end

--- a/lib/chainweb/pact/resources/yield.ex
+++ b/lib/chainweb/pact/resources/yield.ex
@@ -1,0 +1,29 @@
+defmodule Kadena.Chainweb.Pact.Resources.Yield do
+  @moduledoc """
+  `Yield` struct definition.
+  """
+
+  alias Kadena.Chainweb.Mapping
+  alias Kadena.Chainweb.Pact.Resources.Provenance
+
+  @behaviour Kadena.Chainweb.Resource
+
+  @type data :: map()
+  @type provenance :: Provenance.t() | nil
+
+  @type t :: %__MODULE__{
+          data: data(),
+          provenance: provenance()
+        }
+
+  defstruct [:data, :provenance]
+
+  @mapping [provenance: {:struct, Provenance}]
+
+  @impl true
+  def new(attrs) do
+    %__MODULE__{}
+    |> Mapping.build(attrs)
+    |> Mapping.parse(@mapping)
+  end
+end

--- a/test/chainweb/pact/resources/command_result_test.exs
+++ b/test/chainweb/pact/resources/command_result_test.exs
@@ -1,0 +1,157 @@
+defmodule Kadena.Chainweb.Pact.Resources.CommandResultTest do
+  @moduledoc """
+  `CommandResult` struct definition tests.
+  """
+
+  use ExUnit.Case
+
+  alias Kadena.Test.Fixtures.Chainweb
+
+  alias Kadena.Types.{Base64Url, ChainID, PactValue, PactValuesList}
+
+  alias Kadena.Chainweb.Pact.Resources.{
+    CommandResult,
+    Continuation,
+    MetaDataResult,
+    PactEvent,
+    PactEventModule,
+    PactEventsList,
+    PactExec,
+    PactResult,
+    Provenance,
+    ResponseMetaData,
+    Yield
+  }
+
+  setup do
+    continuation = %PactExec{
+      continuation: %Continuation{
+        args: %Kadena.Types.PactValue{literal: "pact_value"},
+        def: "coin"
+      },
+      executed: false,
+      pact_id: %Kadena.Types.PactTransactionHash{
+        hash: "yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4"
+      },
+      step: %Kadena.Types.Step{number: 1},
+      step_count: 5,
+      step_has_rollback: false,
+      yield: %Yield{
+        data: %{
+          "amount" => 0.01,
+          "receiver" => "4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc",
+          "receiver_guard" => %{
+            "keys" => ["4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc"],
+            "pred" => "keys-all"
+          },
+          "source_chain" => 0
+        },
+        provenance: %Provenance{
+          module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+          target_chain_id: %ChainID{id: "1"}
+        }
+      }
+    }
+
+    events = %PactEventsList{
+      pact_events: [
+        %PactEvent{
+          module: %PactEventModule{name: "coin", namespace: nil},
+          module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+          name: "TRANSFER",
+          params: %PactValuesList{
+            pact_values: [
+              %PactValue{literal: "account1"},
+              %PactValue{literal: "account2"},
+              %PactValue{literal: Decimal.new("0.000050")}
+            ]
+          }
+        }
+      ]
+    }
+
+    gas = 5
+    logs = "wsATyGqckuIvlm89hhd2j4t6RMkCrcwJe_oeCYr7Th8"
+
+    response_meta_data = %ResponseMetaData{
+      block_hash: "kZCKTbL3ubONngiGQsJh4fGtP1xrhAoUvcTsqi3uCGg",
+      block_height: 2708,
+      block_time: 1_656_709_048_955_370,
+      prev_block_hash: "LD_o60RB4xnMgLyzkedNV6v-hbCCnx6WXRQy9WDKTgs",
+      public_meta: %MetaDataResult{
+        chain_id: %ChainID{id: ""},
+        creation_time: 0,
+        gas_limit: 10,
+        gas_price: 0,
+        sender: "",
+        ttl: 0
+      }
+    }
+
+    req_key = %Base64Url{url: "uolsidh4DWN-D44FoElnosL8e5-cGCGn_0l2Nct5mq8"}
+    result = %PactResult{data: %PactValue{literal: 3}, status: :success}
+    tx_id = 123_456
+
+    %{
+      attrs: Chainweb.fixture("command_result", to_snake: true),
+      continuation: continuation,
+      events: events,
+      gas: gas,
+      logs: logs,
+      response_meta_data: response_meta_data,
+      req_key: req_key,
+      result: result,
+      tx_id: tx_id
+    }
+  end
+
+  test "new/1", %{
+    attrs: attrs,
+    continuation: continuation,
+    events: events,
+    gas: gas,
+    logs: logs,
+    response_meta_data: response_meta_data,
+    req_key: req_key,
+    result: result,
+    tx_id: tx_id
+  } do
+    %CommandResult{
+      continuation: ^continuation,
+      events: ^events,
+      gas: ^gas,
+      logs: ^logs,
+      meta_data: ^response_meta_data,
+      req_key: ^req_key,
+      result: ^result,
+      tx_id: ^tx_id
+    } = CommandResult.new(attrs)
+  end
+
+  test "new/1 with nil tx_id, logs, continuation, meta_data and events", %{
+    attrs: attrs,
+    gas: gas,
+    req_key: req_key,
+    result: result
+  } do
+    attrs = %{
+      attrs
+      | "tx_id" => nil,
+        "logs" => nil,
+        "continuation" => nil,
+        "meta_data" => nil,
+        "events" => nil
+    }
+
+    %CommandResult{
+      continuation: nil,
+      events: nil,
+      gas: ^gas,
+      logs: nil,
+      meta_data: nil,
+      req_key: ^req_key,
+      result: ^result,
+      tx_id: nil
+    } = CommandResult.new(attrs)
+  end
+end

--- a/test/chainweb/pact/resources/continuation_test.exs
+++ b/test/chainweb/pact/resources/continuation_test.exs
@@ -1,0 +1,106 @@
+defmodule Kadena.Chainweb.Pact.Resources.ContinuationTest do
+  @moduledoc """
+  `Continuation` struct definition tests.
+  """
+
+  use ExUnit.Case
+
+  alias Kadena.Chainweb.Pact.Resources.Continuation
+
+  alias Kadena.Types.{
+    PactDecimal,
+    PactInt,
+    PactValue,
+    PactValuesList
+  }
+
+  setup do
+    %{
+      attrs: %{
+        "def" => "coin",
+        "args" => "pact_value"
+      }
+    }
+  end
+
+  test "new/1 with args as string", %{attrs: attrs} do
+    %Continuation{
+      args: %PactValue{literal: "pact_value"},
+      def: "coin"
+    } = Continuation.new(attrs)
+  end
+
+  test "new/1 with args as integer", %{attrs: attrs} do
+    attrs = Map.put(attrs, "args", 1)
+
+    %Continuation{
+      args: %PactValue{literal: 1},
+      def: "coin"
+    } = Continuation.new(attrs)
+  end
+
+  test "new/1 with args as integer not in range", %{attrs: attrs} do
+    attrs = Map.put(attrs, "args", 9_007_199_254_740_992)
+
+    %Continuation{
+      args: %PactValue{
+        literal: %PactInt{
+          raw_value: 9_007_199_254_740_992,
+          value: "9007199254740992"
+        }
+      },
+      def: "coin"
+    } = Continuation.new(attrs)
+  end
+
+  test "new/1 with args as float", %{attrs: attrs} do
+    attrs = Map.put(attrs, "args", 0.01)
+    decimal = Decimal.new("0.01")
+
+    %Continuation{
+      args: %PactValue{literal: ^decimal},
+      def: "coin"
+    } = Continuation.new(attrs)
+  end
+
+  test "new/1 with args as string decimal", %{attrs: attrs} do
+    attrs = Map.put(attrs, "args", "9007199254740992.553")
+    decimal = Decimal.new("9007199254740992.553")
+
+    %Continuation{
+      args: %PactValue{
+        literal: %PactDecimal{
+          raw_value: ^decimal,
+          value: "9007199254740992.553"
+        }
+      },
+      def: "coin"
+    } = Continuation.new(attrs)
+  end
+
+  test "new/1 with args as boolean", %{attrs: attrs} do
+    attrs = Map.put(attrs, "args", true)
+
+    %Continuation{
+      args: %PactValue{literal: true},
+      def: "coin"
+    } = Continuation.new(attrs)
+  end
+
+  test "new/1 with args as list", %{attrs: attrs} do
+    attrs = Map.put(attrs, "args", ["COIN.gas", 0.01])
+    decimal = Decimal.new("0.01")
+
+    %Continuation{
+      args: %PactValue{
+        literal: %PactValuesList{
+          pact_values: [
+            %PactValue{literal: "COIN.gas"},
+            %PactValue{literal: ^decimal}
+          ]
+        }
+      },
+      def: "coin"
+    } = Continuation.new(attrs)
+  end
+end

--- a/test/chainweb/pact/resources/listen_response_test.exs
+++ b/test/chainweb/pact/resources/listen_response_test.exs
@@ -1,0 +1,164 @@
+defmodule Kadena.Chainweb.Pact.Resources.ListenResponseTest do
+  @moduledoc """
+  `ListenResponse` struct definition tests.
+  """
+
+  use ExUnit.Case
+
+  alias Kadena.Test.Fixtures.Chainweb
+
+  alias Kadena.Types.{
+    Base64Url,
+    ChainID,
+    PactTransactionHash,
+    PactValue,
+    PactValuesList,
+    Step
+  }
+
+  alias Kadena.Chainweb.Pact.Resources.{
+    Continuation,
+    ListenResponse,
+    MetaDataResult,
+    PactEvent,
+    PactEventModule,
+    PactEventsList,
+    PactExec,
+    PactResult,
+    Provenance,
+    ResponseMetaData,
+    Yield
+  }
+
+  setup do
+    continuation = %PactExec{
+      continuation: %Continuation{
+        args: %PactValue{literal: "pact_value"},
+        def: "coin"
+      },
+      executed: false,
+      pact_id: %PactTransactionHash{
+        hash: "yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4"
+      },
+      step: %Step{number: 1},
+      step_count: 5,
+      step_has_rollback: false,
+      yield: %Yield{
+        data: %{
+          "amount" => 0.01,
+          "receiver" => "4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc",
+          "receiver_guard" => %{
+            "keys" => ["4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc"],
+            "pred" => "keys-all"
+          },
+          "source_chain" => 0
+        },
+        provenance: %Provenance{
+          module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+          target_chain_id: %ChainID{id: "1"}
+        }
+      }
+    }
+
+    events = %PactEventsList{
+      pact_events: [
+        %PactEvent{
+          module: %PactEventModule{name: "coin", namespace: nil},
+          module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+          name: "TRANSFER",
+          params: %PactValuesList{
+            pact_values: [
+              %PactValue{literal: "account1"},
+              %PactValue{literal: "account2"},
+              %PactValue{literal: Decimal.new("0.000050")}
+            ]
+          }
+        }
+      ]
+    }
+
+    gas = 5
+    logs = "wsATyGqckuIvlm89hhd2j4t6RMkCrcwJe_oeCYr7Th8"
+
+    response_meta_data = %ResponseMetaData{
+      block_hash: "kZCKTbL3ubONngiGQsJh4fGtP1xrhAoUvcTsqi3uCGg",
+      block_height: 2708,
+      block_time: 1_656_709_048_955_370,
+      prev_block_hash: "LD_o60RB4xnMgLyzkedNV6v-hbCCnx6WXRQy9WDKTgs",
+      public_meta: %MetaDataResult{
+        chain_id: %ChainID{id: ""},
+        creation_time: 0,
+        gas_limit: 10,
+        gas_price: 0,
+        sender: "",
+        ttl: 0
+      }
+    }
+
+    req_key = %Base64Url{url: "uolsidh4DWN-D44FoElnosL8e5-cGCGn_0l2Nct5mq8"}
+    result = %PactResult{data: %PactValue{literal: 3}, status: :success}
+    tx_id = 123_456
+
+    %{
+      attrs: Chainweb.fixture("command_result", to_snake: true),
+      continuation: continuation,
+      events: events,
+      gas: gas,
+      logs: logs,
+      response_meta_data: response_meta_data,
+      req_key: req_key,
+      result: result,
+      tx_id: tx_id
+    }
+  end
+
+  test "new/1", %{
+    attrs: attrs,
+    continuation: continuation,
+    events: events,
+    gas: gas,
+    logs: logs,
+    response_meta_data: response_meta_data,
+    req_key: req_key,
+    result: result,
+    tx_id: tx_id
+  } do
+    %ListenResponse{
+      continuation: ^continuation,
+      events: ^events,
+      gas: ^gas,
+      logs: ^logs,
+      meta_data: ^response_meta_data,
+      req_key: ^req_key,
+      result: ^result,
+      tx_id: ^tx_id
+    } = ListenResponse.new(attrs)
+  end
+
+  test "new/1 with nil tx_id, logs, continuation, meta_data and events", %{
+    attrs: attrs,
+    gas: gas,
+    req_key: req_key,
+    result: result
+  } do
+    attrs = %{
+      attrs
+      | "tx_id" => nil,
+        "logs" => nil,
+        "continuation" => nil,
+        "meta_data" => nil,
+        "events" => nil
+    }
+
+    %ListenResponse{
+      continuation: nil,
+      events: nil,
+      gas: ^gas,
+      logs: nil,
+      meta_data: nil,
+      req_key: ^req_key,
+      result: ^result,
+      tx_id: nil
+    } = ListenResponse.new(attrs)
+  end
+end

--- a/test/chainweb/pact/resources/local_response_test.exs
+++ b/test/chainweb/pact/resources/local_response_test.exs
@@ -1,0 +1,164 @@
+defmodule Kadena.Chainweb.Pact.Resources.LocalResponseTest do
+  @moduledoc """
+  `LocalResponse` struct definition tests.
+  """
+
+  use ExUnit.Case
+
+  alias Kadena.Chainweb.Pact.Resources.{
+    Continuation,
+    LocalResponse,
+    MetaDataResult,
+    PactEvent,
+    PactEventModule,
+    PactEventsList,
+    PactExec,
+    PactResult,
+    Provenance,
+    ResponseMetaData,
+    Yield
+  }
+
+  alias Kadena.Test.Fixtures.Chainweb
+
+  alias Kadena.Types.{
+    Base64Url,
+    ChainID,
+    PactTransactionHash,
+    PactValue,
+    PactValuesList,
+    Step
+  }
+
+  setup do
+    continuation = %PactExec{
+      continuation: %Continuation{
+        args: %PactValue{literal: "pact_value"},
+        def: "coin"
+      },
+      executed: false,
+      pact_id: %PactTransactionHash{
+        hash: "yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4"
+      },
+      step: %Step{number: 1},
+      step_count: 5,
+      step_has_rollback: false,
+      yield: %Yield{
+        data: %{
+          "amount" => 0.01,
+          "receiver" => "4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc",
+          "receiver_guard" => %{
+            "keys" => ["4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc"],
+            "pred" => "keys-all"
+          },
+          "source_chain" => 0
+        },
+        provenance: %Provenance{
+          module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+          target_chain_id: %ChainID{id: "1"}
+        }
+      }
+    }
+
+    events = %PactEventsList{
+      pact_events: [
+        %PactEvent{
+          module: %PactEventModule{name: "coin", namespace: nil},
+          module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+          name: "TRANSFER",
+          params: %PactValuesList{
+            pact_values: [
+              %PactValue{literal: "account1"},
+              %PactValue{literal: "account2"},
+              %PactValue{literal: Decimal.new("0.000050")}
+            ]
+          }
+        }
+      ]
+    }
+
+    gas = 5
+    logs = "wsATyGqckuIvlm89hhd2j4t6RMkCrcwJe_oeCYr7Th8"
+
+    response_meta_data = %ResponseMetaData{
+      block_hash: "kZCKTbL3ubONngiGQsJh4fGtP1xrhAoUvcTsqi3uCGg",
+      block_height: 2708,
+      block_time: 1_656_709_048_955_370,
+      prev_block_hash: "LD_o60RB4xnMgLyzkedNV6v-hbCCnx6WXRQy9WDKTgs",
+      public_meta: %MetaDataResult{
+        chain_id: %ChainID{id: ""},
+        creation_time: 0,
+        gas_limit: 10,
+        gas_price: 0,
+        sender: "",
+        ttl: 0
+      }
+    }
+
+    req_key = %Base64Url{url: "uolsidh4DWN-D44FoElnosL8e5-cGCGn_0l2Nct5mq8"}
+    result = %PactResult{data: %PactValue{literal: 3}, status: :success}
+    tx_id = 123_456
+
+    %{
+      attrs: Chainweb.fixture("command_result", to_snake: true),
+      continuation: continuation,
+      events: events,
+      gas: gas,
+      logs: logs,
+      response_meta_data: response_meta_data,
+      req_key: req_key,
+      result: result,
+      tx_id: tx_id
+    }
+  end
+
+  test "new/1", %{
+    attrs: attrs,
+    continuation: continuation,
+    events: events,
+    gas: gas,
+    logs: logs,
+    response_meta_data: response_meta_data,
+    req_key: req_key,
+    result: result,
+    tx_id: tx_id
+  } do
+    %LocalResponse{
+      continuation: ^continuation,
+      events: ^events,
+      gas: ^gas,
+      logs: ^logs,
+      meta_data: ^response_meta_data,
+      req_key: ^req_key,
+      result: ^result,
+      tx_id: ^tx_id
+    } = LocalResponse.new(attrs)
+  end
+
+  test "new/1 with nil tx_id, logs, continuation, meta_data and events", %{
+    attrs: attrs,
+    gas: gas,
+    req_key: req_key,
+    result: result
+  } do
+    attrs = %{
+      attrs
+      | "tx_id" => nil,
+        "logs" => nil,
+        "continuation" => nil,
+        "meta_data" => nil,
+        "events" => nil
+    }
+
+    %LocalResponse{
+      continuation: nil,
+      events: nil,
+      gas: ^gas,
+      logs: nil,
+      meta_data: nil,
+      req_key: ^req_key,
+      result: ^result,
+      tx_id: nil
+    } = LocalResponse.new(attrs)
+  end
+end

--- a/test/chainweb/pact/resources/meta_data_result_test.exs
+++ b/test/chainweb/pact/resources/meta_data_result_test.exs
@@ -1,0 +1,34 @@
+defmodule Kadena.Chainweb.Pact.Resources.MetaDataResultTest do
+  @moduledoc """
+  `MetaDataResultTest` struct definition tests.
+  """
+
+  use ExUnit.Case
+
+  alias Kadena.Chainweb.Pact.Resources.MetaDataResult
+  alias Kadena.Types.ChainID
+
+  setup do
+    %{
+      attrs: %{
+        "chain_id" => "0",
+        "creation_time" => 0,
+        "gas_limit" => 10,
+        "gas_price" => 0,
+        "sender" => "",
+        "ttl" => 0
+      }
+    }
+  end
+
+  test "new/1", %{attrs: attrs} do
+    %MetaDataResult{
+      chain_id: %ChainID{id: "0"},
+      creation_time: 0,
+      gas_limit: 10,
+      gas_price: 0,
+      sender: "",
+      ttl: 0
+    } = MetaDataResult.new(attrs)
+  end
+end

--- a/test/chainweb/pact/resources/pact_event_module_test.exs
+++ b/test/chainweb/pact/resources/pact_event_module_test.exs
@@ -1,0 +1,28 @@
+defmodule Kadena.Chainweb.Pact.Resources.PactEventModuleTest do
+  @moduledoc """
+  `PactEventModule` struct definition tests.
+  """
+
+  use ExUnit.Case
+
+  alias Kadena.Chainweb.Pact.Resources.PactEventModule
+
+  setup do
+    %{
+      attrs: %{
+        "name" => "coin",
+        "namespace" => "free"
+      }
+    }
+  end
+
+  test "new/1", %{attrs: attrs} do
+    %PactEventModule{name: "coin", namespace: "free"} = PactEventModule.new(attrs)
+  end
+
+  test "new/1 with nil namespace", %{attrs: attrs} do
+    attrs = Map.put(attrs, "namespace", nil)
+
+    %PactEventModule{name: "coin", namespace: nil} = PactEventModule.new(attrs)
+  end
+end

--- a/test/chainweb/pact/resources/pact_event_test.exs
+++ b/test/chainweb/pact/resources/pact_event_test.exs
@@ -1,0 +1,45 @@
+defmodule Kadena.Chainweb.Pact.Resources.PactEventTest do
+  @moduledoc """
+  `PactEvent` struct definition tests.
+  """
+
+  use ExUnit.Case
+
+  alias Kadena.Types.{PactValue, PactValuesList}
+  alias Kadena.Chainweb.Pact.Resources.{PactEvent, PactEventModule}
+
+  setup do
+    %{
+      attrs: %{
+        "module" => %{
+          "name" => "coin",
+          "namespace" => nil
+        },
+        "module_hash" => "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+        "name" => "TRANSFER",
+        "params" => [
+          "account1",
+          "account2",
+          0.00005
+        ]
+      }
+    }
+  end
+
+  test "new/1", %{attrs: attrs} do
+    decimal = Decimal.new("0.000050")
+
+    %PactEvent{
+      module: %PactEventModule{name: "coin", namespace: nil},
+      module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+      name: "TRANSFER",
+      params: %PactValuesList{
+        pact_values: [
+          %PactValue{literal: "account1"},
+          %PactValue{literal: "account2"},
+          %PactValue{literal: ^decimal}
+        ]
+      }
+    } = PactEvent.new(attrs)
+  end
+end

--- a/test/chainweb/pact/resources/pact_events_list_test.exs
+++ b/test/chainweb/pact/resources/pact_events_list_test.exs
@@ -1,0 +1,55 @@
+defmodule Kadena.Chainweb.Pact.Resources.PactEventsListTest do
+  @moduledoc """
+  `PactEventsList` struct definition tests.
+  """
+
+  use ExUnit.Case
+
+  alias Kadena.Chainweb.Pact.Resources.{PactEvent, PactEventsList}
+
+  setup do
+    pact_event_1_attrs = %{
+      "module" => %{
+        "name" => "coin",
+        "namespace" => nil
+      },
+      "module_hash" => "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+      "name" => "TRANSFER",
+      "params" => [
+        "account1",
+        "account2",
+        0.00005
+      ]
+    }
+
+    pact_event_2_attrs = %{
+      "module" => %{
+        "name" => "coin",
+        "namespace" => nil
+      },
+      "module_hash" => "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP5",
+      "name" => "TRANSFER",
+      "params" => [
+        "account3",
+        "account4",
+        0.00005
+      ]
+    }
+
+    %{
+      pact_events: [pact_event_1_attrs, pact_event_2_attrs],
+      pact_event_1: PactEvent.new(pact_event_1_attrs),
+      pact_event_2: PactEvent.new(pact_event_2_attrs)
+    }
+  end
+
+  test "new/1", %{
+    pact_events: pact_events,
+    pact_event_1: pact_event_1,
+    pact_event_2: pact_event_2
+  } do
+    %PactEventsList{
+      pact_events: [^pact_event_1, ^pact_event_2]
+    } = PactEventsList.new(pact_events)
+  end
+end

--- a/test/chainweb/pact/resources/pact_exec_test.exs
+++ b/test/chainweb/pact/resources/pact_exec_test.exs
@@ -1,0 +1,116 @@
+defmodule Kadena.Chainweb.Pact.Resources.PactExecTest do
+  @moduledoc """
+  `PactExec` struct definition tests.
+  """
+  use ExUnit.Case
+
+  alias Kadena.Types.{ChainID, PactTransactionHash, PactValue, Step}
+  alias Kadena.Chainweb.Pact.Resources.{Continuation, PactExec, Provenance, Yield}
+
+  setup do
+    attrs = %{
+      "continuation" => %{"args" => "pact_value", "def" => "coin"},
+      "executed" => false,
+      "pact_id" => "yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4",
+      "step" => 1,
+      "step_count" => 5,
+      "step_has_rollback" => false,
+      "yield" => %{
+        "data" => %{
+          "amount" => 0.01,
+          "receiver" => "4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc",
+          "receiver_guard" => %{
+            "keys" => ["4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc"],
+            "pred" => "keys-all"
+          },
+          "source_chain" => 0
+        },
+        "provenance" => %{
+          "module_hash" => "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+          "target_chain_id" => "1"
+        }
+      }
+    }
+
+    continuation = %Continuation{
+      args: %PactValue{literal: "pact_value"},
+      def: "coin"
+    }
+
+    executed = false
+    pact_id = %PactTransactionHash{hash: "yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4"}
+    step = %Step{number: 1}
+    step_count = 5
+    step_has_rollback = false
+
+    yield = %Yield{
+      data: %{
+        "amount" => 0.01,
+        "receiver" => "4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc",
+        "receiver_guard" => %{
+          "keys" => ["4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc"],
+          "pred" => "keys-all"
+        },
+        "source_chain" => 0
+      },
+      provenance: %Provenance{
+        module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+        target_chain_id: %ChainID{id: "1"}
+      }
+    }
+
+    %{
+      attrs: attrs,
+      continuation: continuation,
+      executed: executed,
+      pact_id: pact_id,
+      step: step,
+      step_count: step_count,
+      step_has_rollback: step_has_rollback,
+      yield: yield
+    }
+  end
+
+  test "new/1", %{
+    attrs: attrs,
+    continuation: continuation,
+    executed: executed,
+    pact_id: pact_id,
+    step: step,
+    step_count: step_count,
+    step_has_rollback: step_has_rollback,
+    yield: yield
+  } do
+    %PactExec{
+      continuation: ^continuation,
+      executed: ^executed,
+      pact_id: ^pact_id,
+      step: ^step,
+      step_count: ^step_count,
+      step_has_rollback: ^step_has_rollback,
+      yield: ^yield
+    } = PactExec.new(attrs)
+  end
+
+  test "new/1 with nil executed and yield", %{
+    attrs: attrs,
+    continuation: continuation,
+    pact_id: pact_id,
+    step: step,
+    step_count: step_count,
+    step_has_rollback: step_has_rollback
+  } do
+    attrs = Map.put(attrs, "executed", nil)
+    attrs = Map.put(attrs, "yield", nil)
+
+    %PactExec{
+      continuation: ^continuation,
+      executed: nil,
+      pact_id: ^pact_id,
+      step: ^step,
+      step_count: ^step_count,
+      step_has_rollback: ^step_has_rollback,
+      yield: nil
+    } = PactExec.new(attrs)
+  end
+end

--- a/test/chainweb/pact/resources/pact_result_test.exs
+++ b/test/chainweb/pact/resources/pact_result_test.exs
@@ -1,0 +1,22 @@
+defmodule Kadena.Chainweb.Pact.Resources.PactResultTest do
+  @moduledoc """
+  `PactResult` struct definition tests.
+  """
+
+  use ExUnit.Case
+
+  alias Kadena.Chainweb.Pact.Resources.PactResult
+  alias Kadena.Types.PactValue
+
+  describe "new/1" do
+    test "with a valid success status" do
+      %PactResult{status: :success, data: %PactValue{literal: 3}} =
+        PactResult.new(%{"status" => "success", "data" => 3})
+    end
+
+    test "with a valid failure status" do
+      %PactResult{status: :failure, data: %{}} =
+        PactResult.new(%{"status" => "failure", "data" => %{}})
+    end
+  end
+end

--- a/test/chainweb/pact/resources/poll_response_test.exs
+++ b/test/chainweb/pact/resources/poll_response_test.exs
@@ -1,0 +1,134 @@
+defmodule Kadena.Chainweb.Pact.Resources.PollResponseTest do
+  @moduledoc """
+  `PollResponse` struct definition tests.
+  """
+
+  use ExUnit.Case
+
+  alias Kadena.Chainweb.Pact.Resources.{
+    CommandResult,
+    PactEvent,
+    PactEventModule,
+    PactEventsList,
+    PactResult,
+    PollResponse,
+    ResponseMetaData
+  }
+
+  alias Kadena.Test.Fixtures.Chainweb
+
+  alias Kadena.Types.{
+    Base64Url,
+    PactValue,
+    PactValuesList
+  }
+
+  setup do
+    command_result_1 = %CommandResult{
+      continuation: nil,
+      events: %PactEventsList{
+        pact_events: [
+          %PactEvent{
+            module: %PactEventModule{
+              name: "coin",
+              namespace: nil
+            },
+            module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+            name: "TRANSFER",
+            params: %PactValuesList{
+              pact_values: [
+                %PactValue{
+                  literal: "k:c891d6761ed2c4ccadbe6a1142803fd34fedfe9db110149cd1d8e2a7bc90dc2f"
+                },
+                %PactValue{
+                  literal: "6d87fd6e5e47185cb421459d2888bddba7a6c0f2c4ae5246d5f38f993818bb89"
+                },
+                %PactValue{literal: Decimal.new("0.000607")}
+              ]
+            }
+          }
+        ]
+      },
+      gas: 607,
+      logs: "OQzCLMH0ycZ0HPoN1F-2Rcifc4RuR4RmcO6t2iJI6A8",
+      meta_data: %ResponseMetaData{
+        block_hash: "eNpIVqyanLWY3sGszNfgYN8YXWXDXfUsWbE_vWcNDlY",
+        block_height: 3_281_769,
+        block_time: 1_670_883_254_243_347,
+        prev_block_hash: "Tw4Z1exNzIinUFe3Y-rrbqp-iMo6NvQJQggMSeVNayw",
+        public_meta: nil
+      },
+      req_key: %Base64Url{
+        url: "bKT10kNSeAyE4LgfFInhorKpK_tNLcNjsaWgug4v82s"
+      },
+      result: %PactResult{
+        data: %PactValue{literal: "Write succeeded"},
+        status: :success
+      },
+      tx_id: 20_160_180
+    }
+
+    command_result_2 = %CommandResult{
+      continuation: nil,
+      events: %PactEventsList{
+        pact_events: [
+          %PactEvent{
+            module: %PactEventModule{
+              name: "coin",
+              namespace: nil
+            },
+            module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+            name: "TRANSFER",
+            params: %PactValuesList{
+              pact_values: [
+                %PactValue{
+                  literal: "k:f99185285730c5414c0a1ec68924598b175827890fad20c18548a9b27d79ce2a"
+                },
+                %PactValue{
+                  literal: "6d87fd6e5e47185cb421459d2888bddba7a6c0f2c4ae5246d5f38f993818bb89"
+                },
+                %PactValue{literal: Decimal.new("0.000509")}
+              ]
+            }
+          }
+        ]
+      },
+      gas: 509,
+      logs: "_sMtjYp5hzhZSUgY72XoamRC0MJRJ_FlZ4IV6FQBK7I",
+      meta_data: %ResponseMetaData{
+        block_hash: "eNpIVqyanLWY3sGszNfgYN8YXWXDXfUsWbE_vWcNDlY",
+        block_height: 3_281_769,
+        block_time: 1_670_883_254_243_347,
+        prev_block_hash: "Tw4Z1exNzIinUFe3Y-rrbqp-iMo6NvQJQggMSeVNayw",
+        public_meta: nil
+      },
+      req_key: %Base64Url{
+        url: "ysx7BoerE0QpflZKkFhSjDZmvMf4xtZ0OxSL1EOckz0"
+      },
+      result: %PactResult{
+        data: %PactValue{literal: "Write succeeded"},
+        status: :success
+      },
+      tx_id: 20_160_174
+    }
+
+    %{
+      attrs: Chainweb.fixture("poll", to_snake: true),
+      command_result_1: command_result_1,
+      command_result_2: command_result_2
+    }
+  end
+
+  test "new/1", %{
+    attrs: attrs,
+    command_result_1: command_result_1,
+    command_result_2: command_result_2
+  } do
+    %PollResponse{
+      results: [
+        ^command_result_1,
+        ^command_result_2
+      ]
+    } = PollResponse.new(attrs)
+  end
+end

--- a/test/chainweb/pact/resources/provenance_test.exs
+++ b/test/chainweb/pact/resources/provenance_test.exs
@@ -1,0 +1,26 @@
+defmodule Kadena.Chainweb.Pact.Resources.ProvenanceTest do
+  @moduledoc """
+  `Provenance` struct definition tests.
+  """
+
+  alias Kadena.Chainweb.Pact.Resources.Provenance
+  alias Kadena.Types.ChainID
+
+  use ExUnit.Case
+
+  setup do
+    %{
+      attrs: %{
+        "module_hash" => "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+        "target_chain_id" => "1"
+      }
+    }
+  end
+
+  test "new/1", %{attrs: attrs} do
+    %Provenance{
+      module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+      target_chain_id: %ChainID{id: "1"}
+    } = Provenance.new(attrs)
+  end
+end

--- a/test/chainweb/pact/resources/response_meta_data_test.exs
+++ b/test/chainweb/pact/resources/response_meta_data_test.exs
@@ -1,0 +1,58 @@
+defmodule Kadena.Chainweb.Pact.Resources.ResponseMetaDataTest do
+  @moduledoc """
+  `ChainwebResponseMetaData` struct definition tests.
+  """
+
+  use ExUnit.Case
+
+  alias Kadena.Chainweb.Pact.Resources.{MetaDataResult, ResponseMetaData}
+  alias Kadena.Types.ChainID
+
+  setup do
+    %{
+      attrs: %{
+        "block_hash" => "kZCKTbL3ubONngiGQsJh4fGtP1xrhAoUvcTsqi3uCGg",
+        "block_height" => 2708,
+        "block_time" => 1_656_709_048_955_370,
+        "prev_block_hash" => "LD_o60RB4xnMgLyzkedNV6v-hbCCnx6WXRQy9WDKTgs",
+        "public_meta" => %{
+          "chain_id" => "0",
+          "creation_time" => 0,
+          "gas_limit" => 10,
+          "gas_price" => 0,
+          "sender" => "",
+          "ttl" => 0
+        }
+      }
+    }
+  end
+
+  test "new/1", %{attrs: attrs} do
+    %ResponseMetaData{
+      block_hash: "kZCKTbL3ubONngiGQsJh4fGtP1xrhAoUvcTsqi3uCGg",
+      block_height: 2708,
+      block_time: 1_656_709_048_955_370,
+      prev_block_hash: "LD_o60RB4xnMgLyzkedNV6v-hbCCnx6WXRQy9WDKTgs",
+      public_meta: %MetaDataResult{
+        chain_id: %ChainID{id: "0"},
+        creation_time: 0,
+        gas_limit: 10,
+        gas_price: 0,
+        sender: "",
+        ttl: 0
+      }
+    } = ResponseMetaData.new(attrs)
+  end
+
+  test "new/1 with nil public_meta", %{attrs: attrs} do
+    attrs = Map.put(attrs, "public_meta", nil)
+
+    %ResponseMetaData{
+      block_hash: "kZCKTbL3ubONngiGQsJh4fGtP1xrhAoUvcTsqi3uCGg",
+      block_height: 2708,
+      block_time: 1_656_709_048_955_370,
+      prev_block_hash: "LD_o60RB4xnMgLyzkedNV6v-hbCCnx6WXRQy9WDKTgs",
+      public_meta: nil
+    } = ResponseMetaData.new(attrs)
+  end
+end

--- a/test/chainweb/pact/resources/yield_test.exs
+++ b/test/chainweb/pact/resources/yield_test.exs
@@ -1,0 +1,51 @@
+defmodule Kadena.Chainweb.Pact.Resources.YieldTest do
+  @moduledoc """
+  `Yield` struct definition tests.
+  """
+
+  alias Kadena.Chainweb.Pact.Resources.{Provenance, Yield}
+  alias Kadena.Types.ChainID
+
+  use ExUnit.Case
+
+  setup do
+    data = %{
+      "amount" => 0.01,
+      "receiver" => "4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc",
+      "receiver_guard" => %{
+        "keys" => ["4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc"],
+        "pred" => "keys-all"
+      },
+      "source_chain" => 0
+    }
+
+    provenance = %Provenance{
+      module_hash: "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+      target_chain_id: %ChainID{id: "1"}
+    }
+
+    attrs = %{
+      "data" => data,
+      "provenance" => %{
+        "module_hash" => "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+        "target_chain_id" => "1"
+      }
+    }
+
+    %{
+      attrs: attrs,
+      data: data,
+      provenance: provenance
+    }
+  end
+
+  test "new/1", %{attrs: attrs, data: data, provenance: provenance} do
+    %Yield{data: ^data, provenance: ^provenance} = Yield.new(attrs)
+  end
+
+  test "new/1 with nil provenance", %{attrs: attrs, data: data} do
+    attrs = Map.put(attrs, "provenance", nil)
+
+    %Yield{data: ^data, provenance: nil} = Yield.new(attrs)
+  end
+end

--- a/test/support/fixtures/chainweb.ex
+++ b/test/support/fixtures/chainweb.ex
@@ -3,15 +3,21 @@ defmodule Kadena.Test.Fixtures.Chainweb do
   Mocks Chainweb API responses.
   """
 
+  alias Kadena.Utils.MapCase
+
   @type fixture :: String.t() | atom()
+  @type opts :: Keyword.t()
 
   @fixtures_path "./test/support/fixtures/chainweb/"
 
-  @spec fixture(fixture :: fixture()) :: binary()
-  def fixture(fixture_name) do
+  @spec fixture(fixture :: fixture(), opts :: opts()) :: binary()
+  def fixture(fixture_name, opts \\ []) do
+    to_snake = Keyword.get(opts, :to_snake, false)
+
     fixture_name
     |> to_string()
     |> read_json_file()
+    |> parse_to_snake(to_snake)
   end
 
   @spec read_json_file(filename :: String.t()) :: binary()
@@ -19,4 +25,8 @@ defmodule Kadena.Test.Fixtures.Chainweb do
     file = Path.expand(@fixtures_path <> "#{filename}.json")
     with {:ok, body} <- File.read(file), do: body
   end
+
+  @spec parse_to_snake(body :: binary(), to_snake :: boolean()) :: map() | binary()
+  defp parse_to_snake(body, true), do: body |> Jason.decode!() |> MapCase.to_snake!()
+  defp parse_to_snake(body, false), do: body
 end

--- a/test/support/fixtures/chainweb/command_result.json
+++ b/test/support/fixtures/chainweb/command_result.json
@@ -1,0 +1,67 @@
+{
+  "continuation": {
+    "continuation": {
+      "args": "pact_value",
+      "def": "coin"
+    },
+    "executed": false,
+    "pactId": "yxM0umrtdcvSUZDc_GSjwadH6ELYFCjOqI59Jzqapi4",
+    "step": 1,
+    "stepCount": 5,
+    "stepHasRollback": false,
+    "yield": {
+      "data": {
+        "amount": 0.01,
+        "receiver": "4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc",
+        "receiver_guard": {
+          "keys": [
+            "4f9c46df2fe874d7c1b60f68f8440a444dd716e6b2efba8ee141afdd58c993dc"
+          ],
+          "pred": "keys-all"
+        },
+        "source_chain": 0
+      },
+      "provenance": {
+        "moduleHash": "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+        "targetChainId": "1"
+      }
+    }
+  },
+  "events": [
+    {
+      "module": {
+        "name": "coin",
+        "namespace": null
+      },
+      "moduleHash": "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4",
+      "name": "TRANSFER",
+      "params": [
+        "account1",
+        "account2",
+        5.0e-5
+      ]
+    }
+  ],
+  "gas": 5,
+  "logs": "wsATyGqckuIvlm89hhd2j4t6RMkCrcwJe_oeCYr7Th8",
+  "metaData": {
+    "blockHash": "kZCKTbL3ubONngiGQsJh4fGtP1xrhAoUvcTsqi3uCGg",
+    "blockHeight": 2708,
+    "blockTime": 1656709048955370,
+    "prevBlockHash": "LD_o60RB4xnMgLyzkedNV6v-hbCCnx6WXRQy9WDKTgs",
+    "publicMeta": {
+      "chainId": "",
+      "creationTime": 0,
+      "gasLimit": 10,
+      "gasPrice": 0,
+      "sender": "",
+      "ttl": 0
+    }
+  },
+  "reqKey": "uolsidh4DWN-D44FoElnosL8e5-cGCGn_0l2Nct5mq8",
+  "result": {
+    "data": 3,
+    "status": "success"
+  },
+  "txId": 123456
+}

--- a/test/support/fixtures/chainweb/poll.json
+++ b/test/support/fixtures/chainweb/poll.json
@@ -1,0 +1,66 @@
+{
+  "bKT10kNSeAyE4LgfFInhorKpK_tNLcNjsaWgug4v82s": {
+    "gas": 607,
+    "result": {
+      "status": "success",
+      "data": "Write succeeded"
+    },
+    "reqKey": "bKT10kNSeAyE4LgfFInhorKpK_tNLcNjsaWgug4v82s",
+    "logs": "OQzCLMH0ycZ0HPoN1F-2Rcifc4RuR4RmcO6t2iJI6A8",
+    "events": [
+      {
+        "params": [
+          "k:c891d6761ed2c4ccadbe6a1142803fd34fedfe9db110149cd1d8e2a7bc90dc2f",
+          "6d87fd6e5e47185cb421459d2888bddba7a6c0f2c4ae5246d5f38f993818bb89",
+          6.07e-4
+        ],
+        "name": "TRANSFER",
+        "module": {
+          "namespace": null,
+          "name": "coin"
+        },
+        "moduleHash": "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4"
+      }
+    ],
+    "metaData": {
+      "blockTime": 1670883254243347,
+      "prevBlockHash": "Tw4Z1exNzIinUFe3Y-rrbqp-iMo6NvQJQggMSeVNayw",
+      "blockHash": "eNpIVqyanLWY3sGszNfgYN8YXWXDXfUsWbE_vWcNDlY",
+      "blockHeight": 3281769
+    },
+    "continuation": null,
+    "txId": 20160180
+  },
+  "ysx7BoerE0QpflZKkFhSjDZmvMf4xtZ0OxSL1EOckz0": {
+    "gas": 509,
+    "result": {
+      "status": "success",
+      "data": "Write succeeded"
+    },
+    "reqKey": "ysx7BoerE0QpflZKkFhSjDZmvMf4xtZ0OxSL1EOckz0",
+    "logs": "_sMtjYp5hzhZSUgY72XoamRC0MJRJ_FlZ4IV6FQBK7I",
+    "events": [
+      {
+        "params": [
+          "k:f99185285730c5414c0a1ec68924598b175827890fad20c18548a9b27d79ce2a",
+          "6d87fd6e5e47185cb421459d2888bddba7a6c0f2c4ae5246d5f38f993818bb89",
+          5.09e-4
+        ],
+        "name": "TRANSFER",
+        "module": {
+          "namespace": null,
+          "name": "coin"
+        },
+        "moduleHash": "rE7DU8jlQL9x_MPYuniZJf5ICBTAEHAIFQCB4blofP4"
+      }
+    ],
+    "metaData": {
+      "blockTime": 1670883254243347,
+      "prevBlockHash": "Tw4Z1exNzIinUFe3Y-rrbqp-iMo6NvQJQggMSeVNayw",
+      "blockHash": "eNpIVqyanLWY3sGszNfgYN8YXWXDXfUsWbE_vWcNDlY",
+      "blockHeight": 3281769
+    },
+    "continuation": null,
+    "txId": 20160174
+  }
+}


### PR DESCRIPTION
## Description

`CommandResult` is a pretty important resource for Pact API, so this PR adds everything needed for the `CommandResult`-related resources to work correctly implementing the Mapping module and allowing to build structs from maps coming from Pact API calls.

Closes #163 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
