### PR TITLE
Enable port 443 to allow erlef/setup-beam connections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
             coveralls.io:443
             github.com:443
             repo.hex.pm:443
+            builds.hex.pm:443
 
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: erlef/setup-beam@e3f6ffe2878180f57318bf13febd3933ee81f664 # v1.15.2


### PR DESCRIPTION
## Description

Actions are failing with connections refused
![image](https://github.com/kommitters/kadena.ex/assets/98826652/ca035785-cb90-4fe8-896a-0f19617c4413)

This is because of the security step _Harden Runner_
![image](https://github.com/kommitters/kadena.ex/assets/98826652/1f71865d-3aa1-4708-9114-49a6b458941d)


After enabling the port the action should run correctly

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
